### PR TITLE
Fixes text-buffer handling

### DIFF
--- a/data/qmls/text_text_buffer.qml
+++ b/data/qmls/text_text_buffer.qml
@@ -1,0 +1,18 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis>
+  <renderer-v2 type="RuleRenderer">
+    <rules key="renderer_rules"/>
+    <symbols/>
+  </renderer-v2>
+  <labeling type="rule-based">
+    <rules key="labeling_rules">
+      <rule key="labeling_rule_0">
+        <settings>
+          <text-style fontSize="10.6135611907387" fontLetterSpacing="0" multilineHeight="1" textColor="0,0,0,255" fontFamily="DejaVuSans" fieldName="Sample label"/>
+          <placement predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" xOffset="0" yOffset="0" rotationAngle="0"/>
+          <text-buffer bufferSize="0.7938257993384785" bufferColor="250,250,250,255"/>
+        </settings>
+      </rule>
+    </rules>
+  </labeling>
+</qgis>

--- a/data/styles/text_text_buffer.ts
+++ b/data/styles/text_text_buffer.ts
@@ -1,0 +1,24 @@
+import { Style } from 'geostyler-style';
+
+const labelSample: Style = {
+  name: 'roads_oneways',
+  rules: [
+    {
+      name: '',
+      scaleDenominator: { max: 1000 },
+      symbolizers: [
+        {
+          kind: 'Text',
+          label: 'Sample label',
+          padding: 0,
+          font: ['DejaVuSans'],
+          size: 10.6135611907387,
+          haloColor: '#fafafa',
+          haloWidth: 0.7938257993384785
+        }
+      ]
+    }
+  ]
+} as Style;
+
+export default labelSample;

--- a/src/QGISStyleParser.spec.ts
+++ b/src/QGISStyleParser.spec.ts
@@ -11,6 +11,7 @@ import point_ranges from '../data/styles/point_ranges';
 import point_external_graphic from '../data/styles/point_external_graphic';
 import polygon_simple from '../data/styles/polygon_simple';
 import no_symbolizer from '../data/styles/no_symbolizer';
+import text_text_buffer from '../data/styles/text_text_buffer';
 
 it('QGISStyleParser is defined', () => {
   expect(QGISStyleParser).toBeDefined();
@@ -163,6 +164,15 @@ describe('QMLStyleParser implements StyleParser', () => {
             expect(qgisStyle).toEqual(qml.trim());
           });
       });
+      it('can write QML with text-buffer', async () => {
+      expect.assertions(2);
+      const qml = fs.readFileSync('./data/qmls/text_text_buffer.qml', 'utf8');
+      return styleParser.writeStyle(text_text_buffer)
+        .then((qgisStyle: string) => {
+          expect(qgisStyle).toBeDefined();
+          expect(qgisStyle).toEqual(qml.trim());
+        });
+    });
     });
     describe('LineSymbolizer', () => {
       it('can write a simple QML LineSymbol', async () => {

--- a/src/QGISStyleParser.ts
+++ b/src/QGISStyleParser.ts
@@ -971,6 +971,7 @@ export class QGISStyleParser implements StyleParser {
         if (rule.filter) {
           textRule.$.filter = this.cqlParser.write(rule.filter);
         }
+
         qmlRuleList.push(textRule);
       }
     });

--- a/src/QGISStyleParser.ts
+++ b/src/QGISStyleParser.ts
@@ -960,7 +960,7 @@ export class QGISStyleParser implements StyleParser {
         };
 
         if (textSymbolizer.haloColor) {
-          textRule.settings['text-buffer'] = [{
+          textRule.settings[0]['text-buffer'] = [{
             $: {
               bufferSize: textSymbolizer.haloWidth || `0`,
               bufferColor: this.qmlColorFromHexAndOpacity(textSymbolizer.haloColor, 1)
@@ -971,7 +971,6 @@ export class QGISStyleParser implements StyleParser {
         if (rule.filter) {
           textRule.$.filter = this.cqlParser.write(rule.filter);
         }
-
         qmlRuleList.push(textRule);
       }
     });


### PR DESCRIPTION
This MR

- fixes an incorrect writing of the `text-buffer` into `settings` when a `haloColor`/`haloWidth` is specified in `geostyler-style`
- adds a new test for `text-buffer` property
@KaiVolland @jansule please review