### PR TITLE
Adds line width unit

### DIFF
--- a/data/qmls/line_simple.qml
+++ b/data/qmls/line_simple.qml
@@ -14,6 +14,7 @@
           <prop k="joinstyle" v="round"/>
           <prop k="capstyle" v="square"/>
           <prop k="line_width" v="3"/>
+          <prop k="line_width_unit" v="Pixel"/>
           <prop k="customdash" v="12;12"/>
         </layer>
       </symbol>

--- a/src/QGISStyleParser.ts
+++ b/src/QGISStyleParser.ts
@@ -768,7 +768,8 @@ export class QGISStyleParser implements StyleParser {
       offset_unit: 'Pixel',
       joinstyle: symbolizer.join,
       capstyle: symbolizer.cap,
-      line_width: symbolizer.width
+      line_width: symbolizer.width,
+      line_width_unit: 'Pixel'
     };
     if (symbolizer.dasharray) {
       qmlProps.customdash = symbolizer.dasharray.join(';');


### PR DESCRIPTION
This MR

- adds the property `line_width_unit` with the value `'Pixel'` for `LineSymbols`
- adjusts the corresponding test case for `LineSymbol` objects
- See also https://github.com/geostyler/geostyler/issues/1442, for future work on parsing units

@KaiVolland @jansule please review