### PR TITLE
Uses outline and opacity defaults for polygon fill

### DIFF
--- a/data/qmls/polygon_simple.qml
+++ b/data/qmls/polygon_simple.qml
@@ -15,7 +15,7 @@
           <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
           <prop k="outline_width_unit" v="Pixel"/>
           <prop k="customdash" v="10;2"/>
-          <prop k="outline_color" v="255,7,11,255"/>
+          <prop k="outline_color" v="255,7,11,128"/>
         </layer>
       </symbol>
     </symbols>

--- a/src/QGISStyleParser.ts
+++ b/src/QGISStyleParser.ts
@@ -784,11 +784,11 @@ export class QGISStyleParser implements StyleParser {
   }
 
   getQmlFillSymbolFromSymbolizer(symbolizer: FillSymbolizer): any {
+    const fillOpacity = symbolizer.fillOpacity !== undefined ? symbolizer.fillOpacity : symbolizer.opacity;
+    const outlineOpacity = symbolizer.outlineOpacity !== undefined ? symbolizer.outlineOpacity : symbolizer.opacity;
+
     const qmlProps = {
-      color: this.qmlColorFromHexAndOpacity(
-        symbolizer.color,
-        symbolizer.color ? symbolizer.fillOpacity || symbolizer.opacity : 0
-      ),
+      color: this.qmlColorFromHexAndOpacity(symbolizer.color, fillOpacity),
       offset_map_unit_scale: '3x:0,0,0,0,0,0',
       offset_unit: 'Pixel',
       outline_style: symbolizer.outlineDasharray ? 'dash' : 'solid',
@@ -796,10 +796,7 @@ export class QGISStyleParser implements StyleParser {
       outline_width_map_unit_scale: '3x:0,0,0,0,0,0',
       outline_width_unit: 'Pixel',
       customdash: symbolizer.outlineDasharray ? symbolizer.outlineDasharray.join(';') : undefined,
-      outline_color: this.qmlColorFromHexAndOpacity(
-        symbolizer.outlineColor,
-        symbolizer.outlineWidth ? symbolizer.outlineOpacity || symbolizer.opacity : 0
-      )
+      outline_color: this.qmlColorFromHexAndOpacity(symbolizer.outlineColor, outlineOpacity)
     };
 
     return {

--- a/src/QGISStyleParser.ts
+++ b/src/QGISStyleParser.ts
@@ -785,7 +785,10 @@ export class QGISStyleParser implements StyleParser {
 
   getQmlFillSymbolFromSymbolizer(symbolizer: FillSymbolizer): any {
     const qmlProps = {
-      color: this.qmlColorFromHexAndOpacity(symbolizer.color, symbolizer.opacity),
+      color: this.qmlColorFromHexAndOpacity(
+        symbolizer.color,
+        symbolizer.color ? symbolizer.fillOpacity || symbolizer.opacity : 0
+      ),
       offset_map_unit_scale: '3x:0,0,0,0,0,0',
       offset_unit: 'Pixel',
       outline_style: symbolizer.outlineDasharray ? 'dash' : 'solid',
@@ -793,7 +796,10 @@ export class QGISStyleParser implements StyleParser {
       outline_width_map_unit_scale: '3x:0,0,0,0,0,0',
       outline_width_unit: 'Pixel',
       customdash: symbolizer.outlineDasharray ? symbolizer.outlineDasharray.join(';') : undefined,
-      outline_color: this.qmlColorFromHexAndOpacity(symbolizer.outlineColor, 1)
+      outline_color: this.qmlColorFromHexAndOpacity(
+        symbolizer.outlineColor,
+        symbolizer.outlineWidth ? symbolizer.outlineOpacity || symbolizer.opacity : 0
+      )
     };
 
     return {


### PR DESCRIPTION
This MR

- introduces a distinction between `outlineOpacity` and `fillOpacity` for `FillSymbols` (polygons)
- corrects the test case and uses the opacity value specified in the style (`opacity = 0.5`)
- changes are related to https://github.com/geostyler/geostyler-mapfile-parser/pull/40

@KaiVolland @jansule please review 