### PR TITLE
Refine text labels

### DIFF
--- a/data/qmls/no_symbolizer.qml
+++ b/data/qmls/no_symbolizer.qml
@@ -1,7 +1,4 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
 <qgis>
-  <renderer-v2 type="RuleRenderer">
-    <rules key="renderer_rules"/>
-    <symbols/>
-  </renderer-v2>
+  <renderer-v2 type="nullSymbol"/>
 </qgis>

--- a/data/qmls/point_label.qml
+++ b/data/qmls/point_label.qml
@@ -1,9 +1,6 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
 <qgis>
-  <renderer-v2 type="RuleRenderer">
-    <rules key="renderer_rules"/>
-    <symbols/>
-  </renderer-v2>
+  <renderer-v2 type="nullSymbol"/>
   <labeling type="rule-based">
     <rules key="labeling_rules">
       <rule key="labeling_rule_0" filter="value > 0.1">

--- a/data/qmls/text_text_buffer.qml
+++ b/data/qmls/text_text_buffer.qml
@@ -10,7 +10,7 @@
         <settings>
           <text-style fontSize="10.6135611907387" fontLetterSpacing="0" multilineHeight="1" textColor="0,0,0,255" fontFamily="DejaVuSans" fieldName="Sample label"/>
           <placement predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" xOffset="0" yOffset="0" rotationAngle="0"/>
-          <text-buffer bufferSize="0.7938257993384785" bufferColor="250,250,250,255"/>
+          <text-buffer bufferSize="0.7938257993384785" bufferColor="250,250,250,255" bufferDraw="1" bufferSizeUnits="Pixel" bufferSizeMapUnitScale="3x:0,0,0,0,0,0"/>
         </settings>
       </rule>
     </rules>

--- a/data/qmls/text_text_buffer.qml
+++ b/data/qmls/text_text_buffer.qml
@@ -1,9 +1,6 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
 <qgis>
-  <renderer-v2 type="RuleRenderer">
-    <rules key="renderer_rules"/>
-    <symbols/>
-  </renderer-v2>
+  <renderer-v2 type="nullSymbol"/>
   <labeling type="rule-based">
     <rules key="labeling_rules">
       <rule key="labeling_rule_0">

--- a/src/QGISStyleParser.ts
+++ b/src/QGISStyleParser.ts
@@ -902,7 +902,7 @@ export class QGISStyleParser implements StyleParser {
     const type: string = 'RuleRenderer';
     const rules: any[] = [];
     const symbols: any[] = this.getQmlSymbolsFromStyle(geoStylerStyle, rules);
-    if (rules.length > 0 && symbols.length > 0) {
+    if (rules.length > 0 || symbols.length > 0) {
       return {
         qgis: {
           $: {},

--- a/src/QGISStyleParser.ts
+++ b/src/QGISStyleParser.ts
@@ -964,7 +964,10 @@ export class QGISStyleParser implements StyleParser {
           textRule.settings[0]['text-buffer'] = [{
             $: {
               bufferSize: textSymbolizer.haloWidth || `0`,
-              bufferColor: this.qmlColorFromHexAndOpacity(textSymbolizer.haloColor, 1)
+              bufferColor: this.qmlColorFromHexAndOpacity(textSymbolizer.haloColor, 1),
+              bufferDraw: 1,
+              bufferSizeUnits: 'Pixel',
+              bufferSizeMapUnitScale: '3x:0,0,0,0,0,0'
             }
           }];
         }

--- a/src/QGISStyleParser.ts
+++ b/src/QGISStyleParser.ts
@@ -902,25 +902,38 @@ export class QGISStyleParser implements StyleParser {
     const type: string = 'RuleRenderer';
     const rules: any[] = [];
     const symbols: any[] = this.getQmlSymbolsFromStyle(geoStylerStyle, rules);
-    return {
-      qgis: {
-        $: {},
-        'renderer-v2': [{
-          $: {
-            type
-          },
-          rules: [{
+    if (rules.length > 0 && symbols.length > 0) {
+      return {
+        qgis: {
+          $: {},
+          'renderer-v2': [{
             $: {
-              key: 'renderer_rules'
+              type
             },
-            rule: rules
-          }],
-          symbols: [{
-            symbol: symbols
+            rules: [{
+              $: {
+                key: 'renderer_rules'
+              },
+              rule: rules
+            }],
+            symbols: [{
+              symbol: symbols
+            }]
           }]
-        }]
-      }
-    };
+        }
+      };
+    } else {
+      return {
+        qgis: {
+          $: {},
+          'renderer-v2': [{
+            $: {
+              type: 'nullSymbol'
+            }
+          }]
+        }
+      };
+    }
   }
 
   convertTextSymbolizerRule(qmlRuleList: any[], rule: Rule) {


### PR DESCRIPTION
Previously, empty symbol rules were returned for the labeling style, which resulted in simple labels not being displayed.

With this MR

- the parser checks whether the style to be returned contains rules and symbols for rendering. If this is not the case, a notation to be recognized by QGIS (`<renderer-v2 type="nullSymbol"/>`) used to indicate that there are no symbols or rules to show,
- adds an enhancement to display the buffer for text labels, if defined
- adjusts the tests accordingly to the changes

@jansule @KaiVolland  please review