### PR TITLE
Replace xmldom with @xmldom/xmldom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@types/lodash": "^4.14.190",
         "@types/xml2js": "^0.4.11",
+        "@xmldom/xmldom": "^0.8.6",
         "buffer": "^6.0.3",
         "color": "^4.2.3",
         "core-js": "^3.26.1",
@@ -20,8 +21,7 @@
         "stream": "^0.0.2",
         "string_decoder": "^1.3.0",
         "timers": "^0.1.1",
-        "xml2js": "^0.4.23",
-        "xmldom": "^0.6.0"
+        "xml2js": "^0.4.23"
       },
       "devDependencies": {
         "@babel/core": "^7.20.5",
@@ -3423,6 +3423,14 @@
         "webpack-dev-server": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.6.tgz",
+      "integrity": "sha512-uRjjusqpoqfmRkTaNuLJ2VohVr67Q5YwDATW3VU7PfzTj6IRaihGrYI7zckGZjxQPBIp63nfvJbM+Yu5ICh0Bg==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -12490,14 +12498,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/xmldom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -15057,6 +15057,11 @@
       "integrity": "sha512-Rumq5mHvGXamnOh3O8yLk1sjx8dB30qF1OeR6VC00DIR6SLJ4bwwUGKC4pE7qBFoQyyh0H9sAg3fikYgAqVR0w==",
       "dev": true,
       "requires": {}
+    },
+    "@xmldom/xmldom": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.6.tgz",
+      "integrity": "sha512-uRjjusqpoqfmRkTaNuLJ2VohVr67Q5YwDATW3VU7PfzTj6IRaihGrYI7zckGZjxQPBIp63nfvJbM+Yu5ICh0Bg=="
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -21768,11 +21773,6 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
-    },
-    "xmldom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@types/lodash": "^4.14.190",
     "@types/xml2js": "^0.4.11",
+    "@xmldom/xmldom": "^0.8.6",
     "buffer": "^6.0.3",
     "color": "^4.2.3",
     "core-js": "^3.26.1",
@@ -38,8 +39,7 @@
     "stream": "^0.0.2",
     "string_decoder": "^1.3.0",
     "timers": "^0.1.1",
-    "xml2js": "^0.4.23",
-    "xmldom": "^0.6.0"
+    "xml2js": "^0.4.23"
   },
   "scripts": {
     "build-browser": "webpack --config browser-build.config.js",


### PR DESCRIPTION
[xmldom](https://www.npmjs.com/package/xmldom) package is now abandoneware, see https://github.com/xmldom/xmldom/issues/271 .
The maintained version with fixed critical [CVE](https://github.com/xmldom/xmldom/security/advisories/GHSA-crh6-fp67-6883) is published under a new (scoped) name [@xmldom/xmldom](https://www.npmjs.com/package/@xmldom/xmldom).