### PR TITLE
ci: remove running action on windows

### DIFF
--- a/.github/workflows/on-push-master.yml
+++ b/.github/workflows/on-push-master.yml
@@ -7,12 +7,11 @@ on:
 
 jobs:
   build:
+    runs-on: ubuntu-latest
+
     strategy:
       matrix:
         node-version: [18.x, 20.x]
-        os: [ubuntu-latest, windows-latest]
-
-    runs-on: ${{ matrix.os }}]
 
     steps:
     - name: Checkout sources


### PR DESCRIPTION
this removes window from the github actions as it is not running currently. we can add it again, in case we will need it.