### PR TITLE
Update to work with new QGIS QML Structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [2.1.0](https://github.com/geostyler/geostyler-qgis-parser/compare/v2.0.1...v2.1.0) (2024-06-25)
+
+
+### Features
+
+* prepare next major release ([530fa1e](https://github.com/geostyler/geostyler-qgis-parser/commit/530fa1ee9cde964eec808f543a6661ae4255e051))
+
+
+### Bug Fixes
+
+* **deps:** update dependency geostyler-style to v8 ([1469169](https://github.com/geostyler/geostyler-qgis-parser/commit/1469169e3f1f28a23c3f32ebd6c4b398d35d814f))
+* fix commitlint ([1e9702d](https://github.com/geostyler/geostyler-qgis-parser/commit/1e9702da04686b845d763e965dbf3a86f60ebe58))
+* update cql parser version ([1d80c02](https://github.com/geostyler/geostyler-qgis-parser/commit/1d80c02e1009c3c41b920621054f5712d22bf177))
+
 ## [2.1.0-next.3](https://github.com/geostyler/geostyler-qgis-parser/compare/v2.1.0-next.2...v2.1.0-next.3) (2024-06-21)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [3.0.0](https://github.com/geostyler/geostyler-qgis-parser/compare/v2.1.0...v3.0.0) (2024-06-26)
+
+
+### ⚠ BREAKING CHANGES
+
+* Switches to esm build and updates base packages.
+
+### Bug Fixes
+
+* fix dependency versions ([ecf3004](https://github.com/geostyler/geostyler-qgis-parser/commit/ecf300440cb90f8ec2e703d4ca4ad9a713807073))
+
 ## [2.1.0](https://github.com/geostyler/geostyler-qgis-parser/compare/v2.0.1...v2.1.0) (2024-06-25)
 
 

--- a/data/qmls/line_simple.qml
+++ b/data/qmls/line_simple.qml
@@ -1,23 +1,60 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis>
-  <renderer-v2 type="RuleRenderer">
+<qgis styleCategories="Symbology" version="3.28.4-Firenze">
+  <renderer-v2 type="RuleRenderer" referencescale="-1" enableorderby="0" forceraster="0" symbollevels="0">
     <rules key="renderer_rules">
-      <rule key="renderer_rule_0" symbol="0" label="QGIS Simple Symbol"/>
+      <rule key="renderer_rule_0" label="QGIS Simple Symbol" symbol="0"/>
     </rules>
     <symbols>
-      <symbol type="line" name="0">
-        <layer class="SimpleLine">
-          <prop k="line_color" v="255,0,255,255"/>
-          <prop k="offset" v="2"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="Pixel"/>
-          <prop k="joinstyle" v="round"/>
-          <prop k="capstyle" v="square"/>
-          <prop k="line_width" v="3"/>
-          <prop k="line_width_unit" v="Pixel"/>
-          <prop k="customdash" v="12;12"/>
+      <symbol clip_to_extent="1" type="line" alpha="1" frame_rate="10" name="0" force_rhr="0" is_animated="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleLine" enabled="1" locked="0" pass="0">
+          <Option type="Map">
+            <Option type="QString" value="0" name="align_dash_pattern"/>
+            <Option type="QString" value="square" name="capstyle"/>
+            <Option type="QString" value="12;12" name="customdash"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+            <Option type="QString" value="MM" name="customdash_unit"/>
+            <Option type="QString" value="0" name="dash_pattern_offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
+            <Option type="QString" value="0" name="draw_inside_polygon"/>
+            <Option type="QString" value="round" name="joinstyle"/>
+            <Option type="QString" value="255,0,255,255" name="line_color"/>
+            <Option type="QString" value="solid" name="line_style"/>
+            <Option type="QString" value="3" name="line_width"/>
+            <Option type="QString" value="Pixel" name="line_width_unit"/>
+            <Option type="QString" value="2" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="Pixel" name="offset_unit"/>
+            <Option type="QString" value="0" name="ring_filter"/>
+            <Option type="QString" value="0" name="trim_distance_end"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
+            <Option type="QString" value="0" name="trim_distance_start"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
+            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option type="QString" value="0" name="use_custom_dash"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
   </renderer-v2>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerGeometryType>1</layerGeometryType>
 </qgis>

--- a/data/qmls/line_simple.qml
+++ b/data/qmls/line_simple.qml
@@ -1,60 +1,43 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis styleCategories="Symbology" version="3.28.4-Firenze">
-  <renderer-v2 type="RuleRenderer" referencescale="-1" enableorderby="0" forceraster="0" symbollevels="0">
+<qgis styleCategories="Symbology">
+  <renderer-v2 type="RuleRenderer">
     <rules key="renderer_rules">
-      <rule key="renderer_rule_0" label="QGIS Simple Symbol" symbol="0"/>
+      <rule key="renderer_rule_0" symbol="0" label="QGIS Simple Symbol"/>
     </rules>
     <symbols>
-      <symbol clip_to_extent="1" type="line" alpha="1" frame_rate="10" name="0" force_rhr="0" is_animated="0">
-        <data_defined_properties>
+      <symbol type="line" name="0">
+        <layer class="SimpleLine">
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
-            <Option name="properties"/>
-            <Option type="QString" value="collection" name="type"/>
+            <Option value="0" name="align_dash_pattern"/>
+            <Option value="square" name="capstyle"/>
+            <Option value="12;12" name="customdash"/>
+            <Option value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
+            <Option value="MM" name="customdash_unit"/>
+            <Option value="0" name="dash_pattern_offset"/>
+            <Option value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
+            <Option value="MM" name="dash_pattern_offset_unit"/>
+            <Option value="0" name="draw_inside_polygon"/>
+            <Option value="round" name="joinstyle"/>
+            <Option value="255,0,255,255" name="line_color"/>
+            <Option value="solid" name="line_style"/>
+            <Option value="3" name="line_width"/>
+            <Option value="Pixel" name="line_width_unit"/>
+            <Option value="2" name="offset"/>
+            <Option value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option value="Pixel" name="offset_unit"/>
+            <Option value="0" name="ring_filter"/>
+            <Option value="0" name="trim_distance_end"/>
+            <Option value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
+            <Option value="MM" name="trim_distance_end_unit"/>
+            <Option value="0" name="trim_distance_start"/>
+            <Option value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
+            <Option value="MM" name="trim_distance_start_unit"/>
+            <Option value="0" name="tweak_dash_pattern_on_corners"/>
+            <Option value="0" name="use_custom_dash"/>
+            <Option value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
           </Option>
-        </data_defined_properties>
-        <layer class="SimpleLine" enabled="1" locked="0" pass="0">
-          <Option type="Map">
-            <Option type="QString" value="0" name="align_dash_pattern"/>
-            <Option type="QString" value="square" name="capstyle"/>
-            <Option type="QString" value="12;12" name="customdash"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="customdash_map_unit_scale"/>
-            <Option type="QString" value="MM" name="customdash_unit"/>
-            <Option type="QString" value="0" name="dash_pattern_offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="dash_pattern_offset_map_unit_scale"/>
-            <Option type="QString" value="MM" name="dash_pattern_offset_unit"/>
-            <Option type="QString" value="0" name="draw_inside_polygon"/>
-            <Option type="QString" value="round" name="joinstyle"/>
-            <Option type="QString" value="255,0,255,255" name="line_color"/>
-            <Option type="QString" value="solid" name="line_style"/>
-            <Option type="QString" value="3" name="line_width"/>
-            <Option type="QString" value="Pixel" name="line_width_unit"/>
-            <Option type="QString" value="2" name="offset"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
-            <Option type="QString" value="Pixel" name="offset_unit"/>
-            <Option type="QString" value="0" name="ring_filter"/>
-            <Option type="QString" value="0" name="trim_distance_end"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_end_map_unit_scale"/>
-            <Option type="QString" value="MM" name="trim_distance_end_unit"/>
-            <Option type="QString" value="0" name="trim_distance_start"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="trim_distance_start_map_unit_scale"/>
-            <Option type="QString" value="MM" name="trim_distance_start_unit"/>
-            <Option type="QString" value="0" name="tweak_dash_pattern_on_corners"/>
-            <Option type="QString" value="0" name="use_custom_dash"/>
-            <Option type="QString" value="3x:0,0,0,0,0,0" name="width_map_unit_scale"/>
-          </Option>
-          <data_defined_properties>
-            <Option type="Map">
-              <Option type="QString" value="" name="name"/>
-              <Option name="properties"/>
-              <Option type="QString" value="collection" name="type"/>
-            </Option>
-          </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
   </renderer-v2>
-  <blendMode>0</blendMode>
-  <featureBlendMode>0</featureBlendMode>
-  <layerGeometryType>1</layerGeometryType>
 </qgis>

--- a/data/qmls/no_symbolizer.qml
+++ b/data/qmls/no_symbolizer.qml
@@ -1,4 +1,7 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis>
-  <renderer-v2 type="nullSymbol"/>
+<qgis styleCategories="Symbology" version="3.28.4-Firenze">
+  <renderer-v2 type="nullSymbol" referencescale="-1" enableorderby="0" forceraster="0" symbollevels="0"/>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerGeometryType>1</layerGeometryType>
 </qgis>

--- a/data/qmls/point_categories.qml
+++ b/data/qmls/point_categories.qml
@@ -1,163 +1,215 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis simplifyMaxScale="1" simplifyDrawingTol="1" hasScaleBasedVisibilityFlag="0" styleCategories="AllStyleCategories" simplifyDrawingHints="0" simplifyLocal="1" simplifyAlgorithm="0" version="3.4.3-Madeira" maxScale="0" minScale="1e+8" labelsEnabled="0" readOnly="0">
-  <renderer-v2 forceraster="0" type="categorizedSymbol" attr="Bildpositi" symbollevels="0" enableorderby="0">
+<qgis styleCategories="Symbology" version="3.28.4-Firenze">
+  <renderer-v2 type="categorizedSymbol" referencescale="-1" enableorderby="0" attr="Bildpositi" forceraster="0" symbollevels="0">
     <categories>
-      <category value="1" symbol="0" label="1" render="true"/>
-      <category value="2" symbol="1" label="2" render="true"/>
-      <category value="3" symbol="2" label="3" render="true"/>
-      <category value="" symbol="3" label="" render="true"/>
+      <category type="string" label="1" value="1" render="true" symbol="0"/>
+      <category type="string" label="2" value="2" render="true" symbol="1"/>
+      <category type="string" label="3" value="3" render="true" symbol="2"/>
+      <category type="string" label="" value="" render="true" symbol="3"/>
     </categories>
     <symbols>
-      <symbol type="marker" alpha="1" force_rhr="0" name="0" clip_to_extent="1">
-        <layer locked="0" class="SimpleMarker" enabled="1" pass="0">
-          <prop k="angle" v="0"/>
-          <prop k="color" v="138,220,56,255"/>
-          <prop k="horizontal_anchor_point" v="1"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="name" v="circle"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="35,35,35,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0"/>
-          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="scale_method" v="diameter"/>
-          <prop k="size" v="4"/>
-          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="size_unit" v="MM"/>
-          <prop k="vertical_anchor_point" v="1"/>
+      <symbol clip_to_extent="1" type="marker" alpha="1" frame_rate="10" name="0" force_rhr="0" is_animated="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+          <Option type="Map">
+            <Option type="QString" value="0" name="angle"/>
+            <Option type="QString" value="square" name="cap_style"/>
+            <Option type="QString" value="138,220,56,255" name="color"/>
+            <Option type="QString" value="1" name="horizontal_anchor_point"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="circle" name="name"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="35,35,35,255" name="outline_color"/>
+            <Option type="QString" value="solid" name="outline_style"/>
+            <Option type="QString" value="0" name="outline_width"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+            <Option type="QString" value="MM" name="outline_width_unit"/>
+            <Option type="QString" value="diameter" name="scale_method"/>
+            <Option type="QString" value="4" name="size"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+            <Option type="QString" value="MM" name="size_unit"/>
+            <Option type="QString" value="1" name="vertical_anchor_point"/>
+          </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option type="QString" value="" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol type="marker" alpha="1" force_rhr="0" name="1" clip_to_extent="1">
-        <layer locked="0" class="SimpleMarker" enabled="1" pass="0">
-          <prop k="angle" v="0"/>
-          <prop k="color" v="234,93,93,255"/>
-          <prop k="horizontal_anchor_point" v="1"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="name" v="circle"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="35,35,35,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0"/>
-          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="scale_method" v="diameter"/>
-          <prop k="size" v="4"/>
-          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="size_unit" v="MM"/>
-          <prop k="vertical_anchor_point" v="1"/>
+      <symbol clip_to_extent="1" type="marker" alpha="1" frame_rate="10" name="1" force_rhr="0" is_animated="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+          <Option type="Map">
+            <Option type="QString" value="0" name="angle"/>
+            <Option type="QString" value="square" name="cap_style"/>
+            <Option type="QString" value="234,93,93,255" name="color"/>
+            <Option type="QString" value="1" name="horizontal_anchor_point"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="circle" name="name"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="35,35,35,255" name="outline_color"/>
+            <Option type="QString" value="solid" name="outline_style"/>
+            <Option type="QString" value="0" name="outline_width"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+            <Option type="QString" value="MM" name="outline_width_unit"/>
+            <Option type="QString" value="diameter" name="scale_method"/>
+            <Option type="QString" value="4" name="size"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+            <Option type="QString" value="MM" name="size_unit"/>
+            <Option type="QString" value="1" name="vertical_anchor_point"/>
+          </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option type="QString" value="" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol type="marker" alpha="1" force_rhr="0" name="2" clip_to_extent="1">
-        <layer locked="0" class="SimpleMarker" enabled="1" pass="0">
-          <prop k="angle" v="0"/>
-          <prop k="color" v="105,219,219,255"/>
-          <prop k="horizontal_anchor_point" v="1"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="name" v="circle"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="35,35,35,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0"/>
-          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="scale_method" v="diameter"/>
-          <prop k="size" v="4"/>
-          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="size_unit" v="MM"/>
-          <prop k="vertical_anchor_point" v="1"/>
+      <symbol clip_to_extent="1" type="marker" alpha="1" frame_rate="10" name="2" force_rhr="0" is_animated="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+          <Option type="Map">
+            <Option type="QString" value="0" name="angle"/>
+            <Option type="QString" value="square" name="cap_style"/>
+            <Option type="QString" value="105,219,219,255" name="color"/>
+            <Option type="QString" value="1" name="horizontal_anchor_point"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="circle" name="name"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="35,35,35,255" name="outline_color"/>
+            <Option type="QString" value="solid" name="outline_style"/>
+            <Option type="QString" value="0" name="outline_width"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+            <Option type="QString" value="MM" name="outline_width_unit"/>
+            <Option type="QString" value="diameter" name="scale_method"/>
+            <Option type="QString" value="4" name="size"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+            <Option type="QString" value="MM" name="size_unit"/>
+            <Option type="QString" value="1" name="vertical_anchor_point"/>
+          </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option type="QString" value="" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol type="marker" alpha="1" force_rhr="0" name="3" clip_to_extent="1">
-        <layer locked="0" class="SimpleMarker" enabled="1" pass="0">
-          <prop k="angle" v="0"/>
-          <prop k="color" v="158,110,205,255"/>
-          <prop k="horizontal_anchor_point" v="1"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="name" v="circle"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="35,35,35,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0"/>
-          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="scale_method" v="diameter"/>
-          <prop k="size" v="4"/>
-          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="size_unit" v="MM"/>
-          <prop k="vertical_anchor_point" v="1"/>
+      <symbol clip_to_extent="1" type="marker" alpha="1" frame_rate="10" name="3" force_rhr="0" is_animated="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+          <Option type="Map">
+            <Option type="QString" value="0" name="angle"/>
+            <Option type="QString" value="square" name="cap_style"/>
+            <Option type="QString" value="158,110,205,255" name="color"/>
+            <Option type="QString" value="1" name="horizontal_anchor_point"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="circle" name="name"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="35,35,35,255" name="outline_color"/>
+            <Option type="QString" value="solid" name="outline_style"/>
+            <Option type="QString" value="0" name="outline_width"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+            <Option type="QString" value="MM" name="outline_width_unit"/>
+            <Option type="QString" value="diameter" name="scale_method"/>
+            <Option type="QString" value="4" name="size"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+            <Option type="QString" value="MM" name="size_unit"/>
+            <Option type="QString" value="1" name="vertical_anchor_point"/>
+          </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option type="QString" value="" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
     <source-symbol>
-      <symbol type="marker" alpha="1" force_rhr="0" name="0" clip_to_extent="1">
-        <layer locked="0" class="SimpleMarker" enabled="1" pass="0">
-          <prop k="angle" v="0"/>
-          <prop k="color" v="190,178,151,255"/>
-          <prop k="horizontal_anchor_point" v="1"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="name" v="circle"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="35,35,35,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0"/>
-          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="scale_method" v="diameter"/>
-          <prop k="size" v="4"/>
-          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="size_unit" v="MM"/>
-          <prop k="vertical_anchor_point" v="1"/>
+      <symbol clip_to_extent="1" type="marker" alpha="1" frame_rate="10" name="0" force_rhr="0" is_animated="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+          <Option type="Map">
+            <Option type="QString" value="0" name="angle"/>
+            <Option type="QString" value="square" name="cap_style"/>
+            <Option type="QString" value="190,178,151,255" name="color"/>
+            <Option type="QString" value="1" name="horizontal_anchor_point"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="circle" name="name"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="35,35,35,255" name="outline_color"/>
+            <Option type="QString" value="solid" name="outline_style"/>
+            <Option type="QString" value="0" name="outline_width"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+            <Option type="QString" value="MM" name="outline_width_unit"/>
+            <Option type="QString" value="diameter" name="scale_method"/>
+            <Option type="QString" value="4" name="size"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+            <Option type="QString" value="MM" name="size_unit"/>
+            <Option type="QString" value="1" name="vertical_anchor_point"/>
+          </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option type="QString" value="" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </source-symbol>
-    <colorramp type="randomcolors" name="[source]"/>
     <rotation/>
     <sizescale/>
   </renderer-v2>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerGeometryType>0</layerGeometryType>
 </qgis>

--- a/data/qmls/point_external_graphic.qml
+++ b/data/qmls/point_external_graphic.qml
@@ -1,20 +1,51 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis>
-  <renderer-v2 type="RuleRenderer">
+<qgis styleCategories="Symbology" version="3.28.4-Firenze">
+  <renderer-v2 type="RuleRenderer" referencescale="-1" enableorderby="0" forceraster="0" symbollevels="0">
     <rules key="renderer_rules">
-      <rule key="renderer_rule_0" symbol="0" label="QGIS Simple Symbol"/>
+      <rule key="renderer_rule_0" label="QGIS Simple Symbol" symbol="0"/>
     </rules>
     <symbols>
-      <symbol type="marker" name="0">
-        <layer class="SvgMarker">
-          <prop k="angle" v="0"/>
-          <prop k="color" v="125,139,143,255"/>
-          <prop k="name" v="https://upload.wikimedia.org/wikipedia/commons/6/67/OpenLayers_logo.svg"/>
-          <prop k="size" v="69"/>
-          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="size_unit" v="Pixel"/>
+      <symbol clip_to_extent="1" type="marker" alpha="1" frame_rate="10" name="0" force_rhr="0" is_animated="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SvgMarker" enabled="1" locked="0" pass="0">
+          <Option type="Map">
+            <Option type="QString" value="0" name="angle"/>
+            <Option type="QString" value="125,139,143,255" name="color"/>
+            <Option type="QString" value="0" name="fixedAspectRatio"/>
+            <Option type="QString" value="1" name="horizontal_anchor_point"/>
+            <Option type="QString" value="https://upload.wikimedia.org/wikipedia/commons/6/67/OpenLayers_logo.svg" name="name"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="35,35,35,255" name="outline_color"/>
+            <Option type="QString" value="0.2" name="outline_width"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+            <Option type="QString" value="MM" name="outline_width_unit"/>
+            <Option name="parameters"/>
+            <Option type="QString" value="diameter" name="scale_method"/>
+            <Option type="QString" value="69" name="size"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+            <Option type="QString" value="Pixel" name="size_unit"/>
+            <Option type="QString" value="1" name="vertical_anchor_point"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
   </renderer-v2>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerGeometryType>0</layerGeometryType>
 </qgis>

--- a/data/qmls/point_label.qml
+++ b/data/qmls/point_label.qml
@@ -1,14 +1,7 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis>
-  <renderer-v2 type="nullSymbol"/>
-  <labeling type="rule-based">
-    <rules key="labeling_rules">
-      <rule key="labeling_rule_0" filter="value > 0.1">
-        <settings>
-          <text-style fontSize="10" fontLetterSpacing="0" multilineHeight="1" textColor="0,0,0,255" fontFamily="Sans Serif" fieldName="locality_name"/>
-          <placement predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" xOffset="13" yOffset="37" rotationAngle="0"/>
-        </settings>
-      </rule>
-    </rules>
-  </labeling>
+<qgis styleCategories="Symbology" version="3.28.4-Firenze">
+  <renderer-v2 type="nullSymbol" referencescale="-1" enableorderby="0" forceraster="0" symbollevels="0"/>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerGeometryType>0</layerGeometryType>
 </qgis>

--- a/data/qmls/point_multiple_symbols.qml
+++ b/data/qmls/point_multiple_symbols.qml
@@ -1,38 +1,82 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis>
-  <renderer-v2 type="RuleRenderer">
+<qgis styleCategories="Symbology" version="3.28.4-Firenze">
+  <renderer-v2 type="RuleRenderer" referencescale="-1" enableorderby="0" forceraster="0" symbollevels="0">
     <rules key="renderer_rules">
-      <rule key="renderer_rule_0" symbol="0" label="QGIS Simple Symbol"/>
+      <rule key="renderer_rule_0" label="QGIS Simple Symbol" symbol="0"/>
     </rules>
     <symbols>
-      <symbol type="marker" name="0">
-        <layer class="SimpleMarker">
-          <prop k="angle" v="0"/>
-          <prop k="color" v="75,255,126,255"/>
-          <prop k="name" v="square"/>
-          <prop k="outline_color" v="0,0,0,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="1"/>
-          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="outline_width_unit" v="Pixel"/>
-          <prop k="size" v="24"/>
-          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="size_unit" v="Pixel"/>
+      <symbol clip_to_extent="1" type="marker" alpha="1" frame_rate="10" name="0" force_rhr="0" is_animated="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+          <Option type="Map">
+            <Option type="QString" value="0" name="angle"/>
+            <Option type="QString" value="square" name="cap_style"/>
+            <Option type="QString" value="75,255,126,255" name="color"/>
+            <Option type="QString" value="1" name="horizontal_anchor_point"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="square" name="name"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="0,0,0,255" name="outline_color"/>
+            <Option type="QString" value="solid" name="outline_style"/>
+            <Option type="QString" value="1" name="outline_width"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+            <Option type="QString" value="Pixel" name="outline_width_unit"/>
+            <Option type="QString" value="diameter" name="scale_method"/>
+            <Option type="QString" value="24" name="size"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+            <Option type="QString" value="Pixel" name="size_unit"/>
+            <Option type="QString" value="1" name="vertical_anchor_point"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
         </layer>
-        <layer class="SimpleMarker">
-          <prop k="angle" v="0"/>
-          <prop k="color" v="255,0,0,255"/>
-          <prop k="name" v="circle"/>
-          <prop k="outline_color" v="35,35,35,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0"/>
-          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="outline_width_unit" v="Pixel"/>
-          <prop k="size" v="4"/>
-          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="size_unit" v="Pixel"/>
+        <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+          <Option type="Map">
+            <Option type="QString" value="0" name="angle"/>
+            <Option type="QString" value="square" name="cap_style"/>
+            <Option type="QString" value="255,0,0,255" name="color"/>
+            <Option type="QString" value="1" name="horizontal_anchor_point"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="circle" name="name"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="35,35,35,255" name="outline_color"/>
+            <Option type="QString" value="solid" name="outline_style"/>
+            <Option type="QString" value="0" name="outline_width"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+            <Option type="QString" value="Pixel" name="outline_width_unit"/>
+            <Option type="QString" value="diameter" name="scale_method"/>
+            <Option type="QString" value="4" name="size"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+            <Option type="QString" value="Pixel" name="size_unit"/>
+            <Option type="QString" value="1" name="vertical_anchor_point"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
   </renderer-v2>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerGeometryType>0</layerGeometryType>
 </qgis>

--- a/data/qmls/point_ranges.qml
+++ b/data/qmls/point_ranges.qml
@@ -1,201 +1,273 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis>
-  <renderer-v2 forceraster="0" graduatedMethod="GraduatedColor" type="graduatedSymbol" attr="PlotNr" symbollevels="0" enableorderby="0">
+<qgis styleCategories="Symbology" version="3.28.4-Firenze">
+  <renderer-v2 graduatedMethod="GraduatedColor" type="graduatedSymbol" referencescale="-1" enableorderby="0" attr="PlotNr" forceraster="0" symbollevels="0">
     <ranges>
-      <range symbol="0" upper="20.000000000000000" label=" 1,0000 - 20,0000 " lower="1.000000000000000" render="true"/>
-      <range symbol="1" upper="39.000000000000000" label=" 20,0000 - 39,0000 " lower="20.000000000000000" render="true"/>
-      <range symbol="2" upper="58.000000000000000" label=" 39,0000 - 58,0000 " lower="39.000000000000000" render="true"/>
-      <range symbol="3" upper="77.000000000000000" label=" 58,0000 - 77,0000 " lower="58.000000000000000" render="true"/>
-      <range symbol="4" upper="96.000000000000000" label=" 77,0000 - 96,0000 " lower="77.000000000000000" render="true"/>
+      <range upper="20.000000000000000" label=" 1,0000 - 20,0000 " render="true" symbol="0" lower="1.000000000000000"/>
+      <range upper="39.000000000000000" label=" 20,0000 - 39,0000 " render="true" symbol="1" lower="20.000000000000000"/>
+      <range upper="58.000000000000000" label=" 39,0000 - 58,0000 " render="true" symbol="2" lower="39.000000000000000"/>
+      <range upper="77.000000000000000" label=" 58,0000 - 77,0000 " render="true" symbol="3" lower="58.000000000000000"/>
+      <range upper="96.000000000000000" label=" 77,0000 - 96,0000 " render="true" symbol="4" lower="77.000000000000000"/>
     </ranges>
     <symbols>
-      <symbol type="marker" alpha="1" force_rhr="0" name="0" clip_to_extent="1">
-        <layer locked="0" class="SimpleMarker" enabled="1" pass="0">
-          <prop k="angle" v="0"/>
-          <prop k="color" v="255,255,255,255"/>
-          <prop k="horizontal_anchor_point" v="1"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="name" v="circle"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="35,35,35,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0"/>
-          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="scale_method" v="diameter"/>
-          <prop k="size" v="4"/>
-          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="size_unit" v="MM"/>
-          <prop k="vertical_anchor_point" v="1"/>
+      <symbol clip_to_extent="1" type="marker" alpha="1" frame_rate="10" name="0" force_rhr="0" is_animated="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+          <Option type="Map">
+            <Option type="QString" value="0" name="angle"/>
+            <Option type="QString" value="square" name="cap_style"/>
+            <Option type="QString" value="255,255,255,255" name="color"/>
+            <Option type="QString" value="1" name="horizontal_anchor_point"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="circle" name="name"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="35,35,35,255" name="outline_color"/>
+            <Option type="QString" value="solid" name="outline_style"/>
+            <Option type="QString" value="0" name="outline_width"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+            <Option type="QString" value="MM" name="outline_width_unit"/>
+            <Option type="QString" value="diameter" name="scale_method"/>
+            <Option type="QString" value="4" name="size"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+            <Option type="QString" value="MM" name="size_unit"/>
+            <Option type="QString" value="1" name="vertical_anchor_point"/>
+          </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option type="QString" value="" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol type="marker" alpha="1" force_rhr="0" name="1" clip_to_extent="1">
-        <layer locked="0" class="SimpleMarker" enabled="1" pass="0">
-          <prop k="angle" v="0"/>
-          <prop k="color" v="255,191,191,255"/>
-          <prop k="horizontal_anchor_point" v="1"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="name" v="circle"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="35,35,35,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0"/>
-          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="scale_method" v="diameter"/>
-          <prop k="size" v="4"/>
-          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="size_unit" v="MM"/>
-          <prop k="vertical_anchor_point" v="1"/>
+      <symbol clip_to_extent="1" type="marker" alpha="1" frame_rate="10" name="1" force_rhr="0" is_animated="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+          <Option type="Map">
+            <Option type="QString" value="0" name="angle"/>
+            <Option type="QString" value="square" name="cap_style"/>
+            <Option type="QString" value="255,191,191,255" name="color"/>
+            <Option type="QString" value="1" name="horizontal_anchor_point"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="circle" name="name"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="35,35,35,255" name="outline_color"/>
+            <Option type="QString" value="solid" name="outline_style"/>
+            <Option type="QString" value="0" name="outline_width"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+            <Option type="QString" value="MM" name="outline_width_unit"/>
+            <Option type="QString" value="diameter" name="scale_method"/>
+            <Option type="QString" value="4" name="size"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+            <Option type="QString" value="MM" name="size_unit"/>
+            <Option type="QString" value="1" name="vertical_anchor_point"/>
+          </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option type="QString" value="" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol type="marker" alpha="1" force_rhr="0" name="2" clip_to_extent="1">
-        <layer locked="0" class="SimpleMarker" enabled="1" pass="0">
-          <prop k="angle" v="0"/>
-          <prop k="color" v="255,128,128,255"/>
-          <prop k="horizontal_anchor_point" v="1"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="name" v="circle"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="35,35,35,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0"/>
-          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="scale_method" v="diameter"/>
-          <prop k="size" v="4"/>
-          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="size_unit" v="MM"/>
-          <prop k="vertical_anchor_point" v="1"/>
+      <symbol clip_to_extent="1" type="marker" alpha="1" frame_rate="10" name="2" force_rhr="0" is_animated="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+          <Option type="Map">
+            <Option type="QString" value="0" name="angle"/>
+            <Option type="QString" value="square" name="cap_style"/>
+            <Option type="QString" value="255,128,128,255" name="color"/>
+            <Option type="QString" value="1" name="horizontal_anchor_point"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="circle" name="name"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="35,35,35,255" name="outline_color"/>
+            <Option type="QString" value="solid" name="outline_style"/>
+            <Option type="QString" value="0" name="outline_width"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+            <Option type="QString" value="MM" name="outline_width_unit"/>
+            <Option type="QString" value="diameter" name="scale_method"/>
+            <Option type="QString" value="4" name="size"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+            <Option type="QString" value="MM" name="size_unit"/>
+            <Option type="QString" value="1" name="vertical_anchor_point"/>
+          </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option type="QString" value="" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol type="marker" alpha="1" force_rhr="0" name="3" clip_to_extent="1">
-        <layer locked="0" class="SimpleMarker" enabled="1" pass="0">
-          <prop k="angle" v="0"/>
-          <prop k="color" v="255,64,64,255"/>
-          <prop k="horizontal_anchor_point" v="1"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="name" v="circle"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="35,35,35,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0"/>
-          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="scale_method" v="diameter"/>
-          <prop k="size" v="4"/>
-          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="size_unit" v="MM"/>
-          <prop k="vertical_anchor_point" v="1"/>
+      <symbol clip_to_extent="1" type="marker" alpha="1" frame_rate="10" name="3" force_rhr="0" is_animated="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+          <Option type="Map">
+            <Option type="QString" value="0" name="angle"/>
+            <Option type="QString" value="square" name="cap_style"/>
+            <Option type="QString" value="255,64,64,255" name="color"/>
+            <Option type="QString" value="1" name="horizontal_anchor_point"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="circle" name="name"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="35,35,35,255" name="outline_color"/>
+            <Option type="QString" value="solid" name="outline_style"/>
+            <Option type="QString" value="0" name="outline_width"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+            <Option type="QString" value="MM" name="outline_width_unit"/>
+            <Option type="QString" value="diameter" name="scale_method"/>
+            <Option type="QString" value="4" name="size"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+            <Option type="QString" value="MM" name="size_unit"/>
+            <Option type="QString" value="1" name="vertical_anchor_point"/>
+          </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option type="QString" value="" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
-      <symbol type="marker" alpha="1" force_rhr="0" name="4" clip_to_extent="1">
-        <layer locked="0" class="SimpleMarker" enabled="1" pass="0">
-          <prop k="angle" v="0"/>
-          <prop k="color" v="255,0,0,255"/>
-          <prop k="horizontal_anchor_point" v="1"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="name" v="circle"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="35,35,35,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0"/>
-          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="scale_method" v="diameter"/>
-          <prop k="size" v="4"/>
-          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="size_unit" v="MM"/>
-          <prop k="vertical_anchor_point" v="1"/>
+      <symbol clip_to_extent="1" type="marker" alpha="1" frame_rate="10" name="4" force_rhr="0" is_animated="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+          <Option type="Map">
+            <Option type="QString" value="0" name="angle"/>
+            <Option type="QString" value="square" name="cap_style"/>
+            <Option type="QString" value="255,0,0,255" name="color"/>
+            <Option type="QString" value="1" name="horizontal_anchor_point"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="circle" name="name"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="35,35,35,255" name="outline_color"/>
+            <Option type="QString" value="solid" name="outline_style"/>
+            <Option type="QString" value="0" name="outline_width"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+            <Option type="QString" value="MM" name="outline_width_unit"/>
+            <Option type="QString" value="diameter" name="scale_method"/>
+            <Option type="QString" value="4" name="size"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+            <Option type="QString" value="MM" name="size_unit"/>
+            <Option type="QString" value="1" name="vertical_anchor_point"/>
+          </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option type="QString" value="" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
     <source-symbol>
-      <symbol type="marker" alpha="1" force_rhr="0" name="0" clip_to_extent="1">
-        <layer locked="0" class="SimpleMarker" enabled="1" pass="0">
-          <prop k="angle" v="0"/>
-          <prop k="color" v="138,220,56,255"/>
-          <prop k="horizontal_anchor_point" v="1"/>
-          <prop k="joinstyle" v="bevel"/>
-          <prop k="name" v="circle"/>
-          <prop k="offset" v="0,0"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="MM"/>
-          <prop k="outline_color" v="35,35,35,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0"/>
-          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="outline_width_unit" v="MM"/>
-          <prop k="scale_method" v="diameter"/>
-          <prop k="size" v="4"/>
-          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="size_unit" v="MM"/>
-          <prop k="vertical_anchor_point" v="1"/>
+      <symbol clip_to_extent="1" type="marker" alpha="1" frame_rate="10" name="0" force_rhr="0" is_animated="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+          <Option type="Map">
+            <Option type="QString" value="0" name="angle"/>
+            <Option type="QString" value="square" name="cap_style"/>
+            <Option type="QString" value="138,220,56,255" name="color"/>
+            <Option type="QString" value="1" name="horizontal_anchor_point"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="circle" name="name"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="35,35,35,255" name="outline_color"/>
+            <Option type="QString" value="solid" name="outline_style"/>
+            <Option type="QString" value="0" name="outline_width"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+            <Option type="QString" value="MM" name="outline_width_unit"/>
+            <Option type="QString" value="diameter" name="scale_method"/>
+            <Option type="QString" value="4" name="size"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+            <Option type="QString" value="MM" name="size_unit"/>
+            <Option type="QString" value="1" name="vertical_anchor_point"/>
+          </Option>
           <data_defined_properties>
             <Option type="Map">
-              <Option value="" type="QString" name="name"/>
+              <Option type="QString" value="" name="name"/>
               <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
+              <Option type="QString" value="collection" name="type"/>
             </Option>
           </data_defined_properties>
         </layer>
       </symbol>
     </source-symbol>
     <colorramp type="gradient" name="[source]">
-      <prop k="color1" v="255,255,255,255"/>
-      <prop k="color2" v="255,0,0,255"/>
-      <prop k="discrete" v="0"/>
-      <prop k="rampType" v="gradient"/>
+      <Option type="Map">
+        <Option type="QString" value="255,255,255,255" name="color1"/>
+        <Option type="QString" value="255,0,0,255" name="color2"/>
+        <Option type="QString" value="ccw" name="direction"/>
+        <Option type="QString" value="0" name="discrete"/>
+        <Option type="QString" value="gradient" name="rampType"/>
+        <Option type="QString" value="rgb" name="spec"/>
+      </Option>
     </colorramp>
-    <mode name="equal"/>
-    <symmetricMode enabled="false" astride="false" symmetryPoint="1"/>
+    <classificationMethod id="EqualInterval">
+      <symmetricMode astride="0" symmetrypoint="1" enabled="0"/>
+      <labelFormat labelprecision="0" trimtrailingzeroes="0" format=" %1 - %2 "/>
+      <parameters>
+        <Option/>
+      </parameters>
+      <extraInformation/>
+    </classificationMethod>
     <rotation/>
     <sizescale/>
-    <labelformat decimalplaces="0" format=" %1 - %2 " trimtrailingzeroes="false"/>
   </renderer-v2>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerGeometryType>0</layerGeometryType>
 </qgis>

--- a/data/qmls/point_rules.qml
+++ b/data/qmls/point_rules.qml
@@ -1,57 +1,132 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis>
-  <renderer-v2 type="RuleRenderer">
+<qgis styleCategories="Symbology" version="3.28.4-Firenze">
+  <renderer-v2 type="RuleRenderer" referencescale="-1" enableorderby="0" forceraster="0" symbollevels="0">
     <rules key="renderer_rules">
-      <rule key="renderer_rule_0" symbol="0" label="Bildpositi = 1" scalemindenom="100" scalemaxdenom="2000" filter="Bildpositi = 1"/>
-      <rule key="renderer_rule_1" symbol="1" label="Bildpositi > 1 AND Bildpositi &lt; 3" scalemindenom="100" scalemaxdenom="2000" filter="Bildpositi > 1 AND Bildpositi &lt; 3"/>
-      <rule key="renderer_rule_2" symbol="2" label="Bildpositi = 3" scalemindenom="100" scalemaxdenom="2000" filter="Bildpositi = 3"/>
+      <rule scalemindenom="100" key="renderer_rule_0" filter="Bildpositi = 1" scalemaxdenom="2000" label="Bildpositi = 1" symbol="0"/>
+      <rule scalemindenom="100" key="renderer_rule_1" filter="Bildpositi > 1 AND Bildpositi &lt; 3" scalemaxdenom="2000" label="Bildpositi > 1 AND Bildpositi &lt; 3" symbol="1"/>
+      <rule scalemindenom="100" key="renderer_rule_2" filter="Bildpositi = 3" scalemaxdenom="2000" label="Bildpositi = 3" symbol="2"/>
     </rules>
     <symbols>
-      <symbol type="marker" name="0">
-        <layer class="SimpleMarker">
-          <prop k="angle" v="0"/>
-          <prop k="color" v="75,255,126,255"/>
-          <prop k="name" v="square"/>
-          <prop k="outline_color" v="0,0,0,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="1"/>
-          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="outline_width_unit" v="Pixel"/>
-          <prop k="size" v="24"/>
-          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="size_unit" v="Pixel"/>
+      <symbol clip_to_extent="1" type="marker" alpha="1" frame_rate="10" name="0" force_rhr="0" is_animated="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+          <Option type="Map">
+            <Option type="QString" value="0" name="angle"/>
+            <Option type="QString" value="square" name="cap_style"/>
+            <Option type="QString" value="75,255,126,255" name="color"/>
+            <Option type="QString" value="1" name="horizontal_anchor_point"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="square" name="name"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="0,0,0,255" name="outline_color"/>
+            <Option type="QString" value="solid" name="outline_style"/>
+            <Option type="QString" value="1" name="outline_width"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+            <Option type="QString" value="Pixel" name="outline_width_unit"/>
+            <Option type="QString" value="diameter" name="scale_method"/>
+            <Option type="QString" value="24" name="size"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+            <Option type="QString" value="Pixel" name="size_unit"/>
+            <Option type="QString" value="1" name="vertical_anchor_point"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
-      <symbol type="marker" name="1">
-        <layer class="SimpleMarker">
-          <prop k="angle" v="0"/>
-          <prop k="color" v="145,82,45,255"/>
-          <prop k="name" v="circle"/>
-          <prop k="outline_color" v="35,35,35,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="1"/>
-          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="outline_width_unit" v="Pixel"/>
-          <prop k="size" v="12"/>
-          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="size_unit" v="Pixel"/>
+      <symbol clip_to_extent="1" type="marker" alpha="1" frame_rate="10" name="1" force_rhr="0" is_animated="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+          <Option type="Map">
+            <Option type="QString" value="0" name="angle"/>
+            <Option type="QString" value="square" name="cap_style"/>
+            <Option type="QString" value="145,82,45,255" name="color"/>
+            <Option type="QString" value="1" name="horizontal_anchor_point"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="circle" name="name"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="35,35,35,255" name="outline_color"/>
+            <Option type="QString" value="solid" name="outline_style"/>
+            <Option type="QString" value="1" name="outline_width"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+            <Option type="QString" value="Pixel" name="outline_width_unit"/>
+            <Option type="QString" value="diameter" name="scale_method"/>
+            <Option type="QString" value="12" name="size"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+            <Option type="QString" value="Pixel" name="size_unit"/>
+            <Option type="QString" value="1" name="vertical_anchor_point"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
-      <symbol type="marker" name="2">
-        <layer class="SimpleMarker">
-          <prop k="angle" v="0"/>
-          <prop k="color" v="190,178,151,255"/>
-          <prop k="name" v="circle"/>
-          <prop k="outline_color" v="35,35,35,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="1"/>
-          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="outline_width_unit" v="Pixel"/>
-          <prop k="size" v="12"/>
-          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="size_unit" v="Pixel"/>
+      <symbol clip_to_extent="1" type="marker" alpha="1" frame_rate="10" name="2" force_rhr="0" is_animated="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+          <Option type="Map">
+            <Option type="QString" value="0" name="angle"/>
+            <Option type="QString" value="square" name="cap_style"/>
+            <Option type="QString" value="190,178,151,255" name="color"/>
+            <Option type="QString" value="1" name="horizontal_anchor_point"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="circle" name="name"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="35,35,35,255" name="outline_color"/>
+            <Option type="QString" value="solid" name="outline_style"/>
+            <Option type="QString" value="1" name="outline_width"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+            <Option type="QString" value="Pixel" name="outline_width_unit"/>
+            <Option type="QString" value="diameter" name="scale_method"/>
+            <Option type="QString" value="12" name="size"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+            <Option type="QString" value="Pixel" name="size_unit"/>
+            <Option type="QString" value="1" name="vertical_anchor_point"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
   </renderer-v2>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerGeometryType>0</layerGeometryType>
 </qgis>

--- a/data/qmls/point_simple.qml
+++ b/data/qmls/point_simple.qml
@@ -1,25 +1,52 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis>
-  <renderer-v2 type="RuleRenderer">
+<qgis styleCategories="Symbology" version="3.28.4-Firenze">
+  <renderer-v2 type="RuleRenderer" referencescale="-1" enableorderby="0" forceraster="0" symbollevels="0">
     <rules key="renderer_rules">
-      <rule key="renderer_rule_0" symbol="0" label="QGIS Simple Symbol"/>
+      <rule key="renderer_rule_0" label="QGIS Simple Symbol" symbol="0"/>
     </rules>
     <symbols>
-      <symbol type="marker" name="0">
-        <layer class="SimpleMarker">
-          <prop k="angle" v="0"/>
-          <prop k="color" v="190,178,151,255"/>
-          <prop k="name" v="circle"/>
-          <prop k="outline_color" v="35,35,35,255"/>
-          <prop k="outline_style" v="solid"/>
-          <prop k="outline_width" v="0"/>
-          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="outline_width_unit" v="Pixel"/>
-          <prop k="size" v="4"/>
-          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="size_unit" v="Pixel"/>
+      <symbol clip_to_extent="1" type="marker" alpha="1" frame_rate="10" name="0" force_rhr="0" is_animated="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleMarker" enabled="1" locked="0" pass="0">
+          <Option type="Map">
+            <Option type="QString" value="0" name="angle"/>
+            <Option type="QString" value="square" name="cap_style"/>
+            <Option type="QString" value="190,178,151,255" name="color"/>
+            <Option type="QString" value="1" name="horizontal_anchor_point"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="circle" name="name"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="MM" name="offset_unit"/>
+            <Option type="QString" value="35,35,35,255" name="outline_color"/>
+            <Option type="QString" value="solid" name="outline_style"/>
+            <Option type="QString" value="0" name="outline_width"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="outline_width_map_unit_scale"/>
+            <Option type="QString" value="Pixel" name="outline_width_unit"/>
+            <Option type="QString" value="diameter" name="scale_method"/>
+            <Option type="QString" value="4" name="size"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="size_map_unit_scale"/>
+            <Option type="QString" value="Pixel" name="size_unit"/>
+            <Option type="QString" value="1" name="vertical_anchor_point"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
   </renderer-v2>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerGeometryType>0</layerGeometryType>
 </qgis>

--- a/data/qmls/polygon_simple.qml
+++ b/data/qmls/polygon_simple.qml
@@ -1,23 +1,44 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis>
-  <renderer-v2 type="RuleRenderer">
+<qgis styleCategories="Symbology" version="3.28.4-Firenze">
+  <renderer-v2 type="RuleRenderer" referencescale="-1" enableorderby="0" forceraster="0" symbollevels="0">
     <rules key="renderer_rules">
-      <rule key="renderer_rule_0" symbol="0" label="QGIS Simple Symbol"/>
+      <rule key="renderer_rule_0" label="QGIS Simple Symbol" symbol="0"/>
     </rules>
     <symbols>
-      <symbol type="fill" name="0">
-        <layer class="SimpleFill">
-          <prop k="color" v="75,255,126,128"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="Pixel"/>
-          <prop k="outline_style" v="dash"/>
-          <prop k="outline_width" v="4"/>
-          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="outline_width_unit" v="Pixel"/>
-          <prop k="customdash" v="10;2"/>
-          <prop k="outline_color" v="255,7,11,128"/>
+      <symbol clip_to_extent="1" type="fill" alpha="1" frame_rate="10" name="0" force_rhr="0" is_animated="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+          <Option type="Map">
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+            <Option type="QString" value="75,255,126,128" name="color"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="Pixel" name="offset_unit"/>
+            <Option type="QString" value="255,7,11,128" name="outline_color"/>
+            <Option type="QString" value="dash" name="outline_style"/>
+            <Option type="QString" value="4" name="outline_width"/>
+            <Option type="QString" value="Pixel" name="outline_width_unit"/>
+            <Option type="QString" value="solid" name="style"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
   </renderer-v2>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerGeometryType>2</layerGeometryType>
 </qgis>

--- a/data/qmls/polygon_simple_nostyle.qml
+++ b/data/qmls/polygon_simple_nostyle.qml
@@ -1,23 +1,44 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis>
-  <renderer-v2 type="RuleRenderer">
+<qgis styleCategories="Symbology" version="3.28.4-Firenze">
+  <renderer-v2 type="RuleRenderer" referencescale="-1" enableorderby="0" forceraster="0" symbollevels="0">
     <rules key="renderer_rules">
-      <rule key="renderer_rule_0" symbol="0" label="QGIS Simple Symbol"/>
+      <rule key="renderer_rule_0" label="QGIS Simple Symbol" symbol="0"/>
     </rules>
     <symbols>
-      <symbol type="fill" name="0">
-        <layer class="SimpleFill">
-          <prop k="color" v="75,255,126,128"/>
-          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="offset_unit" v="Pixel"/>
-          <prop k="outline_style" v="dash"/>
-          <prop k="outline_width" v="4"/>
-          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-          <prop k="outline_width_unit" v="Pixel"/>
-          <prop k="outline_color" v="255,7,11,128"/>
-          <prop k="style" v="no"/>
+      <symbol clip_to_extent="1" type="fill" alpha="1" frame_rate="10" name="0" force_rhr="0" is_animated="0">
+        <data_defined_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </data_defined_properties>
+        <layer class="SimpleFill" enabled="1" locked="0" pass="0">
+          <Option type="Map">
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="border_width_map_unit_scale"/>
+            <Option type="QString" value="75,255,126,128" name="color"/>
+            <Option type="QString" value="bevel" name="joinstyle"/>
+            <Option type="QString" value="0,0" name="offset"/>
+            <Option type="QString" value="3x:0,0,0,0,0,0" name="offset_map_unit_scale"/>
+            <Option type="QString" value="Pixel" name="offset_unit"/>
+            <Option type="QString" value="255,7,11,128" name="outline_color"/>
+            <Option type="QString" value="dash" name="outline_style"/>
+            <Option type="QString" value="4" name="outline_width"/>
+            <Option type="QString" value="Pixel" name="outline_width_unit"/>
+            <Option type="QString" value="no" name="style"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
         </layer>
       </symbol>
     </symbols>
   </renderer-v2>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerGeometryType>2</layerGeometryType>
 </qgis>

--- a/data/qmls/text_text_buffer.qml
+++ b/data/qmls/text_text_buffer.qml
@@ -1,15 +1,7 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis>
-  <renderer-v2 type="nullSymbol"/>
-  <labeling type="rule-based">
-    <rules key="labeling_rules">
-      <rule key="labeling_rule_0">
-        <settings>
-          <text-style fontSize="10.6135611907387" fontLetterSpacing="0" multilineHeight="1" textColor="0,0,0,255" fontFamily="DejaVuSans" fieldName="Sample label"/>
-          <placement predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" xOffset="0" yOffset="0" rotationAngle="0"/>
-          <text-buffer bufferSize="0.7938257993384785" bufferColor="250,250,250,255" bufferDraw="1" bufferSizeUnits="Pixel" bufferSizeMapUnitScale="3x:0,0,0,0,0,0"/>
-        </settings>
-      </rule>
-    </rules>
-  </labeling>
+<qgis styleCategories="Symbology" version="3.28.4-Firenze">
+  <renderer-v2 type="nullSymbol" referencescale="-1" enableorderby="0" forceraster="0" symbollevels="0"/>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerGeometryType>0</layerGeometryType>
 </qgis>

--- a/data/qmls_old/line_simple.qml
+++ b/data/qmls_old/line_simple.qml
@@ -1,0 +1,23 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis>
+  <renderer-v2 type="RuleRenderer">
+    <rules key="renderer_rules">
+      <rule key="renderer_rule_0" symbol="0" label="QGIS Simple Symbol"/>
+    </rules>
+    <symbols>
+      <symbol type="line" name="0">
+        <layer class="SimpleLine">
+          <prop k="line_color" v="255,0,255,255"/>
+          <prop k="offset" v="2"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="Pixel"/>
+          <prop k="joinstyle" v="round"/>
+          <prop k="capstyle" v="square"/>
+          <prop k="line_width" v="3"/>
+          <prop k="line_width_unit" v="Pixel"/>
+          <prop k="customdash" v="12;12"/>
+        </layer>
+      </symbol>
+    </symbols>
+  </renderer-v2>
+</qgis>

--- a/data/qmls_old/no_symbolizer.qml
+++ b/data/qmls_old/no_symbolizer.qml
@@ -1,0 +1,4 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis>
+  <renderer-v2 type="nullSymbol"/>
+</qgis>

--- a/data/qmls_old/point_categories.qml
+++ b/data/qmls_old/point_categories.qml
@@ -1,0 +1,163 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis simplifyMaxScale="1" simplifyDrawingTol="1" hasScaleBasedVisibilityFlag="0" styleCategories="AllStyleCategories" simplifyDrawingHints="0" simplifyLocal="1" simplifyAlgorithm="0" version="3.4.3-Madeira" maxScale="0" minScale="1e+8" labelsEnabled="0" readOnly="0">
+  <renderer-v2 forceraster="0" type="categorizedSymbol" attr="Bildpositi" symbollevels="0" enableorderby="0">
+    <categories>
+      <category value="1" symbol="0" label="1" render="true"/>
+      <category value="2" symbol="1" label="2" render="true"/>
+      <category value="3" symbol="2" label="3" render="true"/>
+      <category value="" symbol="3" label="" render="true"/>
+    </categories>
+    <symbols>
+      <symbol type="marker" alpha="1" force_rhr="0" name="0" clip_to_extent="1">
+        <layer locked="0" class="SimpleMarker" enabled="1" pass="0">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="138,220,56,255"/>
+          <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="name" v="circle"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="35,35,35,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="scale_method" v="diameter"/>
+          <prop k="size" v="4"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="MM"/>
+          <prop k="vertical_anchor_point" v="1"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol type="marker" alpha="1" force_rhr="0" name="1" clip_to_extent="1">
+        <layer locked="0" class="SimpleMarker" enabled="1" pass="0">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="234,93,93,255"/>
+          <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="name" v="circle"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="35,35,35,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="scale_method" v="diameter"/>
+          <prop k="size" v="4"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="MM"/>
+          <prop k="vertical_anchor_point" v="1"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol type="marker" alpha="1" force_rhr="0" name="2" clip_to_extent="1">
+        <layer locked="0" class="SimpleMarker" enabled="1" pass="0">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="105,219,219,255"/>
+          <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="name" v="circle"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="35,35,35,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="scale_method" v="diameter"/>
+          <prop k="size" v="4"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="MM"/>
+          <prop k="vertical_anchor_point" v="1"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol type="marker" alpha="1" force_rhr="0" name="3" clip_to_extent="1">
+        <layer locked="0" class="SimpleMarker" enabled="1" pass="0">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="158,110,205,255"/>
+          <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="name" v="circle"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="35,35,35,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="scale_method" v="diameter"/>
+          <prop k="size" v="4"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="MM"/>
+          <prop k="vertical_anchor_point" v="1"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </symbols>
+    <source-symbol>
+      <symbol type="marker" alpha="1" force_rhr="0" name="0" clip_to_extent="1">
+        <layer locked="0" class="SimpleMarker" enabled="1" pass="0">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="190,178,151,255"/>
+          <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="name" v="circle"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="35,35,35,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="scale_method" v="diameter"/>
+          <prop k="size" v="4"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="MM"/>
+          <prop k="vertical_anchor_point" v="1"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </source-symbol>
+    <colorramp type="randomcolors" name="[source]"/>
+    <rotation/>
+    <sizescale/>
+  </renderer-v2>
+</qgis>

--- a/data/qmls_old/point_external_graphic.qml
+++ b/data/qmls_old/point_external_graphic.qml
@@ -1,0 +1,20 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis>
+  <renderer-v2 type="RuleRenderer">
+    <rules key="renderer_rules">
+      <rule key="renderer_rule_0" symbol="0" label="QGIS Simple Symbol"/>
+    </rules>
+    <symbols>
+      <symbol type="marker" name="0">
+        <layer class="SvgMarker">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="125,139,143,255"/>
+          <prop k="name" v="https://upload.wikimedia.org/wikipedia/commons/6/67/OpenLayers_logo.svg"/>
+          <prop k="size" v="69"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="Pixel"/>
+        </layer>
+      </symbol>
+    </symbols>
+  </renderer-v2>
+</qgis>

--- a/data/qmls_old/point_label.qml
+++ b/data/qmls_old/point_label.qml
@@ -1,0 +1,14 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis>
+  <renderer-v2 type="nullSymbol"/>
+  <labeling type="rule-based">
+    <rules key="labeling_rules">
+      <rule key="labeling_rule_0" filter="value > 0.1">
+        <settings>
+          <text-style fontSize="10" fontLetterSpacing="0" multilineHeight="1" textColor="0,0,0,255" fontFamily="Sans Serif" fieldName="locality_name"/>
+          <placement predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" xOffset="13" yOffset="37" rotationAngle="0"/>
+        </settings>
+      </rule>
+    </rules>
+  </labeling>
+</qgis>

--- a/data/qmls_old/point_multiple_symbols.qml
+++ b/data/qmls_old/point_multiple_symbols.qml
@@ -1,0 +1,38 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis>
+  <renderer-v2 type="RuleRenderer">
+    <rules key="renderer_rules">
+      <rule key="renderer_rule_0" symbol="0" label="QGIS Simple Symbol"/>
+    </rules>
+    <symbols>
+      <symbol type="marker" name="0">
+        <layer class="SimpleMarker">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="75,255,126,255"/>
+          <prop k="name" v="square"/>
+          <prop k="outline_color" v="0,0,0,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="1"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="Pixel"/>
+          <prop k="size" v="24"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="Pixel"/>
+        </layer>
+        <layer class="SimpleMarker">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="255,0,0,255"/>
+          <prop k="name" v="circle"/>
+          <prop k="outline_color" v="35,35,35,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="Pixel"/>
+          <prop k="size" v="4"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="Pixel"/>
+        </layer>
+      </symbol>
+    </symbols>
+  </renderer-v2>
+</qgis>

--- a/data/qmls_old/point_ranges.qml
+++ b/data/qmls_old/point_ranges.qml
@@ -1,0 +1,201 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis>
+  <renderer-v2 forceraster="0" graduatedMethod="GraduatedColor" type="graduatedSymbol" attr="PlotNr" symbollevels="0" enableorderby="0">
+    <ranges>
+      <range symbol="0" upper="20.000000000000000" label=" 1,0000 - 20,0000 " lower="1.000000000000000" render="true"/>
+      <range symbol="1" upper="39.000000000000000" label=" 20,0000 - 39,0000 " lower="20.000000000000000" render="true"/>
+      <range symbol="2" upper="58.000000000000000" label=" 39,0000 - 58,0000 " lower="39.000000000000000" render="true"/>
+      <range symbol="3" upper="77.000000000000000" label=" 58,0000 - 77,0000 " lower="58.000000000000000" render="true"/>
+      <range symbol="4" upper="96.000000000000000" label=" 77,0000 - 96,0000 " lower="77.000000000000000" render="true"/>
+    </ranges>
+    <symbols>
+      <symbol type="marker" alpha="1" force_rhr="0" name="0" clip_to_extent="1">
+        <layer locked="0" class="SimpleMarker" enabled="1" pass="0">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="255,255,255,255"/>
+          <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="name" v="circle"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="35,35,35,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="scale_method" v="diameter"/>
+          <prop k="size" v="4"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="MM"/>
+          <prop k="vertical_anchor_point" v="1"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol type="marker" alpha="1" force_rhr="0" name="1" clip_to_extent="1">
+        <layer locked="0" class="SimpleMarker" enabled="1" pass="0">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="255,191,191,255"/>
+          <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="name" v="circle"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="35,35,35,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="scale_method" v="diameter"/>
+          <prop k="size" v="4"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="MM"/>
+          <prop k="vertical_anchor_point" v="1"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol type="marker" alpha="1" force_rhr="0" name="2" clip_to_extent="1">
+        <layer locked="0" class="SimpleMarker" enabled="1" pass="0">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="255,128,128,255"/>
+          <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="name" v="circle"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="35,35,35,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="scale_method" v="diameter"/>
+          <prop k="size" v="4"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="MM"/>
+          <prop k="vertical_anchor_point" v="1"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol type="marker" alpha="1" force_rhr="0" name="3" clip_to_extent="1">
+        <layer locked="0" class="SimpleMarker" enabled="1" pass="0">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="255,64,64,255"/>
+          <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="name" v="circle"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="35,35,35,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="scale_method" v="diameter"/>
+          <prop k="size" v="4"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="MM"/>
+          <prop k="vertical_anchor_point" v="1"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol type="marker" alpha="1" force_rhr="0" name="4" clip_to_extent="1">
+        <layer locked="0" class="SimpleMarker" enabled="1" pass="0">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="255,0,0,255"/>
+          <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="name" v="circle"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="35,35,35,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="scale_method" v="diameter"/>
+          <prop k="size" v="4"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="MM"/>
+          <prop k="vertical_anchor_point" v="1"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </symbols>
+    <source-symbol>
+      <symbol type="marker" alpha="1" force_rhr="0" name="0" clip_to_extent="1">
+        <layer locked="0" class="SimpleMarker" enabled="1" pass="0">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="138,220,56,255"/>
+          <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="name" v="circle"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_color" v="35,35,35,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="scale_method" v="diameter"/>
+          <prop k="size" v="4"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="MM"/>
+          <prop k="vertical_anchor_point" v="1"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option value="" type="QString" name="name"/>
+              <Option name="properties"/>
+              <Option value="collection" type="QString" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </source-symbol>
+    <colorramp type="gradient" name="[source]">
+      <prop k="color1" v="255,255,255,255"/>
+      <prop k="color2" v="255,0,0,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
+    </colorramp>
+    <mode name="equal"/>
+    <symmetricMode enabled="false" astride="false" symmetryPoint="1"/>
+    <rotation/>
+    <sizescale/>
+    <labelformat decimalplaces="0" format=" %1 - %2 " trimtrailingzeroes="false"/>
+  </renderer-v2>
+</qgis>

--- a/data/qmls_old/point_rules.qml
+++ b/data/qmls_old/point_rules.qml
@@ -1,0 +1,57 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis>
+  <renderer-v2 type="RuleRenderer">
+    <rules key="renderer_rules">
+      <rule key="renderer_rule_0" symbol="0" label="Bildpositi = 1" scalemindenom="100" scalemaxdenom="2000" filter="Bildpositi = 1"/>
+      <rule key="renderer_rule_1" symbol="1" label="Bildpositi > 1 AND Bildpositi &lt; 3" scalemindenom="100" scalemaxdenom="2000" filter="Bildpositi > 1 AND Bildpositi &lt; 3"/>
+      <rule key="renderer_rule_2" symbol="2" label="Bildpositi = 3" scalemindenom="100" scalemaxdenom="2000" filter="Bildpositi = 3"/>
+    </rules>
+    <symbols>
+      <symbol type="marker" name="0">
+        <layer class="SimpleMarker">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="75,255,126,255"/>
+          <prop k="name" v="square"/>
+          <prop k="outline_color" v="0,0,0,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="1"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="Pixel"/>
+          <prop k="size" v="24"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="Pixel"/>
+        </layer>
+      </symbol>
+      <symbol type="marker" name="1">
+        <layer class="SimpleMarker">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="145,82,45,255"/>
+          <prop k="name" v="circle"/>
+          <prop k="outline_color" v="35,35,35,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="1"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="Pixel"/>
+          <prop k="size" v="12"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="Pixel"/>
+        </layer>
+      </symbol>
+      <symbol type="marker" name="2">
+        <layer class="SimpleMarker">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="190,178,151,255"/>
+          <prop k="name" v="circle"/>
+          <prop k="outline_color" v="35,35,35,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="1"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="Pixel"/>
+          <prop k="size" v="12"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="Pixel"/>
+        </layer>
+      </symbol>
+    </symbols>
+  </renderer-v2>
+</qgis>

--- a/data/qmls_old/point_simple.qml
+++ b/data/qmls_old/point_simple.qml
@@ -1,0 +1,25 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis>
+  <renderer-v2 type="RuleRenderer">
+    <rules key="renderer_rules">
+      <rule key="renderer_rule_0" symbol="0" label="QGIS Simple Symbol"/>
+    </rules>
+    <symbols>
+      <symbol type="marker" name="0">
+        <layer class="SimpleMarker">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="190,178,151,255"/>
+          <prop k="name" v="circle"/>
+          <prop k="outline_color" v="35,35,35,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="Pixel"/>
+          <prop k="size" v="4"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="Pixel"/>
+        </layer>
+      </symbol>
+    </symbols>
+  </renderer-v2>
+</qgis>

--- a/data/qmls_old/polygon_simple.qml
+++ b/data/qmls_old/polygon_simple.qml
@@ -1,0 +1,23 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis>
+  <renderer-v2 type="RuleRenderer">
+    <rules key="renderer_rules">
+      <rule key="renderer_rule_0" symbol="0" label="QGIS Simple Symbol"/>
+    </rules>
+    <symbols>
+      <symbol type="fill" name="0">
+        <layer class="SimpleFill">
+          <prop k="color" v="75,255,126,128"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="Pixel"/>
+          <prop k="outline_style" v="dash"/>
+          <prop k="outline_width" v="4"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="Pixel"/>
+          <prop k="customdash" v="10;2"/>
+          <prop k="outline_color" v="255,7,11,128"/>
+        </layer>
+      </symbol>
+    </symbols>
+  </renderer-v2>
+</qgis>

--- a/data/qmls_old/polygon_simple_nostyle.qml
+++ b/data/qmls_old/polygon_simple_nostyle.qml
@@ -1,0 +1,23 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis>
+  <renderer-v2 type="RuleRenderer">
+    <rules key="renderer_rules">
+      <rule key="renderer_rule_0" symbol="0" label="QGIS Simple Symbol"/>
+    </rules>
+    <symbols>
+      <symbol type="fill" name="0">
+        <layer class="SimpleFill">
+          <prop k="color" v="75,255,126,128"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="Pixel"/>
+          <prop k="outline_style" v="dash"/>
+          <prop k="outline_width" v="4"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="Pixel"/>
+          <prop k="outline_color" v="255,7,11,128"/>
+          <prop k="style" v="no"/>
+        </layer>
+      </symbol>
+    </symbols>
+  </renderer-v2>
+</qgis>

--- a/data/qmls_old/text_text_buffer.qml
+++ b/data/qmls_old/text_text_buffer.qml
@@ -1,0 +1,15 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis>
+  <renderer-v2 type="nullSymbol"/>
+  <labeling type="rule-based">
+    <rules key="labeling_rules">
+      <rule key="labeling_rule_0">
+        <settings>
+          <text-style fontSize="10.6135611907387" fontLetterSpacing="0" multilineHeight="1" textColor="0,0,0,255" fontFamily="DejaVuSans" fieldName="Sample label"/>
+          <placement predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" xOffset="0" yOffset="0" rotationAngle="0"/>
+          <text-buffer bufferSize="0.7938257993384785" bufferColor="250,250,250,255" bufferDraw="1" bufferSizeUnits="Pixel" bufferSizeMapUnitScale="3x:0,0,0,0,0,0"/>
+        </settings>
+      </rule>
+    </rules>
+  </labeling>
+</qgis>

--- a/data/styles/line_simple.ts
+++ b/data/styles/line_simple.ts
@@ -6,10 +6,10 @@ const pointSimple: Style = {
     name: 'QGIS Simple Symbol',
     symbolizers: [{
       kind: 'Line',
+      cap: 'square',
       color: '#FF00FF',
       width: 3,
       dasharray: [12, 12],
-      cap: 'square',
       join: 'round',
       perpendicularOffset: 2,
       opacity: 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geostyler-qgis-parser",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geostyler-qgis-parser",
-      "version": "2.1.0",
+      "version": "3.0.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "buffer": "^6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "geostyler-qgis-parser",
-  "version": "2.1.0-next.3",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geostyler-qgis-parser",
-      "version": "2.1.0-next.3",
+      "version": "2.1.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "buffer": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geostyler-qgis-parser",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "GeoStyler Style Parser implementation for QGIS Style",
   "main": "dist/QGISStyleParser.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "geostyler-qgis-parser",
-  "version": "2.1.0-next.3",
+  "version": "2.1.0",
   "description": "GeoStyler Style Parser implementation for QGIS Style",
   "main": "dist/QGISStyleParser.js",
   "type": "module",

--- a/src/QGISStyleParser.ts
+++ b/src/QGISStyleParser.ts
@@ -821,7 +821,13 @@ export class QGISStyleParser implements StyleParser {
       $: {
         class: 'SimpleLine'
       },
-      prop: this.propsObjectToQmlSymbolProps(qmlProps)
+      // QGIS Styles are from 228 nested inside a parent Option tag
+      Option: {
+        $: {
+          type: 'Map'
+        },
+        Option: this.propsObjectToQmlSymbolProps(qmlProps)
+      } 
     };
   }
 
@@ -954,8 +960,8 @@ export class QGISStyleParser implements StyleParser {
       const v = properties[k];
       return {
         $: {
-          name: k,
-          value: v
+          value: v,
+          name: k
         }
       };
     }).filter(s => s.$.value !== undefined);
@@ -974,7 +980,9 @@ export class QGISStyleParser implements StyleParser {
     if (rules.length > 0 || symbols.length > 0) {
       return {
         qgis: {
-          $: {},
+          $: {
+            styleCategories: 'Symbology'
+          },
           'renderer-v2': [{
             $: {
               type
@@ -986,7 +994,6 @@ export class QGISStyleParser implements StyleParser {
               rule: rules
             }],
             symbols: [{
-              foo: 'bar',
               symbol: symbols
             }]
           }]

--- a/src/QGISStyleParser.ts
+++ b/src/QGISStyleParser.ts
@@ -49,6 +49,13 @@ type QmlProp = {
   };
 };
 
+type QmlOption = {
+  $: {
+    name: string;
+    value: string;
+  };
+};
+
 type QmlRule = {
   $: {
     filter?: string;
@@ -173,11 +180,16 @@ export class QGISStyleParser implements StyleParser {
    */
   qmlSymbolizerLayerPropsToObject(qmlSymbolizer: any) {
     const qmlMarkerProps: any = {};
-    qmlSymbolizer.prop.forEach((prop: QmlProp) => {
-      const key = prop.$.k;
-      const value = prop.$.v;
+    qmlSymbolizer.Option[0].Option.forEach((option: QmlOption) => {
+      const key = option.$.name;
+      const value = option.$.value;
       qmlMarkerProps[key] = value;
     });
+    // qmlSymbolizer.prop.forEach((prop: QmlProp) => {
+    //   const key = prop.$.k;
+    //   const value = prop.$.v;
+    //   qmlMarkerProps[key] = value;
+    // });
     return qmlMarkerProps;
   }
 
@@ -841,7 +853,7 @@ export class QGISStyleParser implements StyleParser {
       $: {
         class: 'SimpleFill'
       },
-      prop: this.propsObjectToQmlSymbolProps(qmlProps)
+      Option: this.propsObjectToQmlSymbolProps(qmlProps)
     };
   }
 
@@ -891,7 +903,7 @@ export class QGISStyleParser implements StyleParser {
       $: {
         class: 'SvgMarker'
       },
-      prop: this.propsObjectToQmlSymbolProps(qmlProps)
+      Option: this.propsObjectToQmlSymbolProps(qmlProps)
     };
   }
 
@@ -929,7 +941,7 @@ export class QGISStyleParser implements StyleParser {
       $: {
         class: 'SimpleMarker'
       },
-      prop: this.propsObjectToQmlSymbolProps(qmlProps)
+      Option: this.propsObjectToQmlSymbolProps(qmlProps)
     };
   }
 
@@ -937,16 +949,16 @@ export class QGISStyleParser implements StyleParser {
    *
    * @param properties
    */
-  propsObjectToQmlSymbolProps(properties: any): QmlProp[] {
+  propsObjectToQmlSymbolProps(properties: any): QmlOption[] {
     return Object.keys(properties).map(k => {
       const v = properties[k];
       return {
         $: {
-          k,
-          v
+          name: k,
+          value: v
         }
       };
-    }).filter(s => s.$.v !== undefined);
+    }).filter(s => s.$.value !== undefined);
   }
 
   /**
@@ -974,6 +986,7 @@ export class QGISStyleParser implements StyleParser {
               rule: rules
             }],
             symbols: [{
+              foo: 'bar',
               symbol: symbols
             }]
           }]


### PR DESCRIPTION
Based on the fork by @OSHistory referenced in https://github.com/geostyler/geostyler-qgis-parser/issues/455#issuecomment-1552123376 and rebased to current `master` branch. 

Test files still require updating, but having a pull request makes it clearer the changes made to support the new structure. 
I ran into a few issues running the tests, so this is a WIP. 