### PR TITLE
fix: dashed line conversion

### DIFF
--- a/data/qmls/line_simple.qml
+++ b/data/qmls/line_simple.qml
@@ -17,6 +17,7 @@
             <Option name="line_width" value="3" type="QString"/>
             <Option name="line_width_unit" value="Pixel" type="QString"/>
             <Option name="customdash" value="12;12" type="QString"/>
+            <Option name="use_custom_dash" value="1" type="QString"/>
           </Option>
         </layer>
       </symbol>

--- a/data/qmls_old/line_simple.qml
+++ b/data/qmls_old/line_simple.qml
@@ -16,6 +16,7 @@
           <prop k="line_width" v="3"/>
           <prop k="line_width_unit" v="Pixel"/>
           <prop k="customdash" v="12;12"/>
+          <prop k="use_custom_dash" v="1"/>
         </layer>
       </symbol>
     </symbols>


### PR DESCRIPTION
QGIS only honours line.customdash if line.use_custom_dash is 1. Otherwise it honours line.style (same values as fill.outlineStyle).

Make sure we read the right one during reading, and make sure we write line.use_custom_dash=1 when writing custom dashes.