### PR TITLE
handle graphic fills and outline only fills

### DIFF
--- a/src/QGISStyleParser.ts
+++ b/src/QGISStyleParser.ts
@@ -647,15 +647,11 @@ export class QGISStyleParser implements StyleParser {
     const {
       qmlSymbolizerLayerPropsToObject
     } = this;
-    return qmlSymbolizer.layer.map((symbolizerLayer: any) => {
+    return qmlSymbolizer.layer.flatMap((symbolizerLayer: any) => {
       let fillSymbolizer: FillSymbolizer = {
         kind: 'Fill',
       } as FillSymbolizer;
 
-      if (symbolizerLayer.$.class === 'PointPatternFill') {
-        fillSymbolizer.graphicFill = symbolizerLayer.symbol.map(
-          (x: any) => this.getPointSymbolizersFromQmlSymbolizer(x));
-      }
 
       const qmlMarkerProps: any = qmlSymbolizerLayerPropsToObject(symbolizerLayer);
 
@@ -690,7 +686,18 @@ export class QGISStyleParser implements StyleParser {
       if (fillSymbolizer.outlineColor && !fillSymbolizer.color && fillStyle !== 'no'){
         fillSymbolizer.color = 'transparent';
       }
-      return fillSymbolizer;
+
+      if (symbolizerLayer.$.class === 'PointPatternFill') {
+        const graphicFillList: PointSymbolizer[] = symbolizerLayer.symbol.flatMap(
+          (x: any) => this.getPointSymbolizersFromQmlSymbolizer(x));
+        if (graphicFillList.length > 1) {
+          return graphicFillList.map(graphicFill => ({...fillSymbolizer, graphicFill}));
+        }
+        if (graphicFillList.length === 1) {
+          fillSymbolizer.graphicFill = graphicFillList[0];
+        }
+      }
+      return [fillSymbolizer];
     });
   }
 

--- a/src/QGISStyleParser.ts
+++ b/src/QGISStyleParser.ts
@@ -654,9 +654,15 @@ export class QGISStyleParser implements StyleParser {
 
       const qmlMarkerProps: any = qmlSymbolizerLayerPropsToObject(symbolizerLayer);
 
-      const outlineStyle = qmlMarkerProps?.outline_style || 'solid';
+      let outlineStyle = qmlMarkerProps?.outline_style || 'solid';
       if (qmlMarkerProps.outline_color && 'no' !== outlineStyle) {
         fillSymbolizer.outlineColor = this.qmlColorToHex(qmlMarkerProps.outline_color);
+      }
+      // in some cases, QGIS will use line_* instead of outline_*
+      const lineStyle = qmlMarkerProps?.line_style;
+      if (!fillSymbolizer.outlineColor && lineStyle && lineStyle !== 'no') {
+        outlineStyle = lineStyle;
+        fillSymbolizer.outlineColor = this.qmlColorToHex(qmlMarkerProps.line_color);
       }
 
       let fillStyle = qmlMarkerProps?.style || 'solid';
@@ -674,6 +680,11 @@ export class QGISStyleParser implements StyleParser {
         fillSymbolizer.outlineWidth = parseFloat(qmlMarkerProps.outline_width);
       }
 
+      // if you supply a fill with an outline color and no fill color,
+      // it will make the background black.
+      if (fillSymbolizer.outlineColor && !fillSymbolizer.color){
+        fillSymbolizer.color = 'transparent';
+      }
       return fillSymbolizer;
     });
   }

--- a/src/QGISStyleParser.ts
+++ b/src/QGISStyleParser.ts
@@ -652,6 +652,11 @@ export class QGISStyleParser implements StyleParser {
         kind: 'Fill',
       } as FillSymbolizer;
 
+      if (symbolizerLayer.$.class === 'PointPatternFill') {
+        fillSymbolizer.graphicFill = symbolizerLayer.symbol.map(
+          (x: any) => this.getPointSymbolizersFromQmlSymbolizer(x));
+      }
+
       const qmlMarkerProps: any = qmlSymbolizerLayerPropsToObject(symbolizerLayer);
 
       let outlineStyle = qmlMarkerProps?.outline_style || 'solid';
@@ -682,7 +687,7 @@ export class QGISStyleParser implements StyleParser {
 
       // if you supply a fill with an outline color and no fill color,
       // it will make the background black.
-      if (fillSymbolizer.outlineColor && !fillSymbolizer.color){
+      if (fillSymbolizer.outlineColor && !fillSymbolizer.color && fillStyle !== 'no'){
         fillSymbolizer.color = 'transparent';
       }
       return fillSymbolizer;


### PR DESCRIPTION
- handles graphic fills.  Multiple graphic fills will be split into multiple layers.
- handles outline-only fills by adding a transparent color.

Concurrently developed with https://github.com/geostyler/geostyler-mapbox-parser/pull/365