### PR TITLE
Rebased PR: handle graphic fills and outline only fills

### DIFF
--- a/data/qmls/polygon_outline_only.qml
+++ b/data/qmls/polygon_outline_only.qml
@@ -1,0 +1,24 @@
+
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.28.0-Firenze">
+  <renderer-v2 type="RuleRenderer">
+    <rules key="renderer_rules">
+      <rule key="renderer_rule_0" symbol="0" label="QGIS Simple Symbol"/>
+    </rules>
+    <symbols>
+      <symbol type="fill" name="0">
+        <layer class="SimpleFill">
+          <Option type="Map">
+            <Option name="offset_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="offset_unit" value="Pixel" type="QString"/>
+            <Option name="outline_style" value="solid" type="QString"/>
+            <Option name="outline_width" value="4" type="QString"/>
+            <Option name="outline_width_map_unit_scale" value="3x:0,0,0,0,0,0" type="QString"/>
+            <Option name="outline_width_unit" value="Pixel" type="QString"/>
+            <Option name="outline_color" value="255,7,11,128" type="QString"/>
+          </Option>
+        </layer>
+      </symbol>
+    </symbols>
+  </renderer-v2>
+</qgis>

--- a/data/qmls/polygon_point_pattern_fill.qml
+++ b/data/qmls/polygon_point_pattern_fill.qml
@@ -1,0 +1,92 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.28.0-Firenze">
+  <renderer-v2 type="RuleRenderer">
+    <rules key="renderer_rules">
+      <rule key="renderer_rule_0" symbol="0" label="QGIS Simple Symbol"/>
+    </rules>
+    <symbols>
+      <symbol type="fill" name="0">
+        <layer enabled="1" pass="0" class="PointPatternFill" locked="0" id="{0f95bad9-4c7f-43a9-b4b5-0cfe38afc29b}">
+          <Option type="Map">
+            <Option name="angle" type="double" value="0"/>
+            <Option name="clip_mode" type="QString" value="shape"/>
+            <Option name="coordinate_reference" type="QString" value="feature"/>
+            <Option name="displacement_x" type="QString" value="1.2"/>
+            <Option name="displacement_x_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="displacement_x_unit" type="QString" value="MM"/>
+            <Option name="displacement_y" type="QString" value="0"/>
+            <Option name="displacement_y_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="displacement_y_unit" type="QString" value="MM"/>
+            <Option name="distance_x" type="QString" value="2.4"/>
+            <Option name="distance_x_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="distance_x_unit" type="QString" value="MM"/>
+            <Option name="distance_y" type="QString" value="2.4"/>
+            <Option name="distance_y_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="distance_y_unit" type="QString" value="MM"/>
+            <Option name="offset_x" type="QString" value="0"/>
+            <Option name="offset_x_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="offset_x_unit" type="QString" value="MM"/>
+            <Option name="offset_y" type="QString" value="0"/>
+            <Option name="offset_y_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="offset_y_unit" type="QString" value="MM"/>
+            <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="outline_width_unit" type="QString" value="MM"/>
+            <Option name="random_deviation_x" type="QString" value="0"/>
+            <Option name="random_deviation_x_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="random_deviation_x_unit" type="QString" value="MM"/>
+            <Option name="random_deviation_y" type="QString" value="0"/>
+            <Option name="random_deviation_y_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+            <Option name="random_deviation_y_unit" type="QString" value="MM"/>
+            <Option name="seed" type="QString" value="160171014"/>
+          </Option>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option name="name" type="QString" value=""/>
+              <Option name="properties"/>
+              <Option name="type" type="QString" value="collection"/>
+            </Option>
+          </data_defined_properties>
+          <symbol name="@0@0" frame_rate="10" clip_to_extent="1" force_rhr="0" is_animated="0" type="marker" alpha="1">
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" type="QString" value=""/>
+                <Option name="properties"/>
+                <Option name="type" type="QString" value="collection"/>
+              </Option>
+            </data_defined_properties>
+            <layer enabled="1" pass="0" class="SimpleMarker" locked="0" id="{a59889af-9d9d-4afc-8df2-8a21a621ce93}">
+              <Option type="Map">
+                <Option name="angle" type="QString" value="0"/>
+                <Option name="cap_style" type="QString" value="square"/>
+                <Option name="color" type="QString" value="0,108,43,255"/>
+                <Option name="horizontal_anchor_point" type="QString" value="1"/>
+                <Option name="joinstyle" type="QString" value="bevel"/>
+                <Option name="name" type="QString" value="circle"/>
+                <Option name="offset" type="QString" value="0,0"/>
+                <Option name="offset_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="offset_unit" type="QString" value="MM"/>
+                <Option name="outline_color" type="QString" value="0,0,0,255"/>
+                <Option name="outline_style" type="QString" value="solid"/>
+                <Option name="outline_width" type="QString" value="0.2"/>
+                <Option name="outline_width_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="outline_width_unit" type="QString" value="MM"/>
+                <Option name="scale_method" type="QString" value="diameter"/>
+                <Option name="size" type="QString" value="0.6"/>
+                <Option name="size_map_unit_scale" type="QString" value="3x:0,0,0,0,0,0"/>
+                <Option name="size_unit" type="QString" value="MM"/>
+                <Option name="vertical_anchor_point" type="QString" value="1"/>
+              </Option>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""/>
+                  <Option name="properties"/>
+                  <Option name="type" type="QString" value="collection"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </layer>
+      </symbol>
+    </symbols>
+  </renderer-v2>
+</qgis>

--- a/data/qmls_old/polygon_outline_only.qml
+++ b/data/qmls_old/polygon_outline_only.qml
@@ -1,0 +1,22 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.22.16-Białowieża">
+  <renderer-v2 type="RuleRenderer">
+    <rules key="renderer_rules">
+      <rule key="renderer_rule_0" symbol="0" label="QGIS Simple Symbol"/>
+    </rules>
+    <symbols>
+      <symbol type="fill" name="0">
+        <layer class="SimpleFill">
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="Pixel"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="4"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="Pixel"/>
+          <prop k="customdash" v="10;2"/>
+          <prop k="outline_color" v="255,7,11,128"/>
+        </layer>
+      </symbol>
+    </symbols>
+  </renderer-v2>
+</qgis>

--- a/data/qmls_old/polygon_point_pattern_fill.qml
+++ b/data/qmls_old/polygon_point_pattern_fill.qml
@@ -1,0 +1,57 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.22.16-Białowieża">
+  <renderer-v2 type="RuleRenderer">
+    <rules key="renderer_rules">
+      <rule key="renderer_rule_0" symbol="0" label="QGIS Simple Symbol"/>
+    </rules>
+    <symbols>
+      <symbol type="fill" name="0">
+          <layer pass="0" enabled="1" class="PointPatternFill" locked="0">
+          <prop k="displacement_x" v="1.2"/>
+          <prop k="displacement_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="displacement_x_unit" v="MM"/>
+          <prop k="displacement_y" v="0"/>
+          <prop k="displacement_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="displacement_y_unit" v="MM"/>
+          <prop k="distance_x" v="2.4"/>
+          <prop k="distance_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="distance_x_unit" v="MM"/>
+          <prop k="distance_y" v="2.4"/>
+          <prop k="distance_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="distance_y_unit" v="MM"/>
+          <prop k="offset_x" v="0"/>
+          <prop k="offset_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_x_unit" v="MM"/>
+          <prop k="offset_y" v="0"/>
+          <prop k="offset_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_y_unit" v="MM"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <symbol clip_to_extent="1" force_rhr="0" type="marker" name="@0@0" alpha="1">
+            <layer pass="0" enabled="1" class="SimpleMarker" locked="0">
+              <prop k="angle" v="0"/>
+              <prop k="cap_style" v="square"/>
+              <prop k="color" v="0,108,43,255"/>
+              <prop k="horizontal_anchor_point" v="1"/>
+              <prop k="joinstyle" v="bevel"/>
+              <prop k="name" v="circle"/>
+              <prop k="offset" v="0,0"/>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+              <prop k="offset_unit" v="MM"/>
+              <prop k="outline_color" v="0,0,0,255"/>
+              <prop k="outline_style" v="solid"/>
+              <prop k="outline_width" v="0.2"/>
+              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+              <prop k="outline_width_unit" v="MM"/>
+              <prop k="scale_method" v="diameter"/>
+              <prop k="size" v="0.6"/>
+              <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+              <prop k="size_unit" v="MM"/>
+              <prop k="vertical_anchor_point" v="1"/>
+            </layer>
+          </symbol>
+        </layer>
+      </symbol>
+    </symbols>
+  </renderer-v2>
+</qgis>

--- a/data/styles/polygon_outline_only.ts
+++ b/data/styles/polygon_outline_only.ts
@@ -1,0 +1,16 @@
+import { Style } from 'geostyler-style';
+
+const polygonOutlineOnly: Style = {
+  name: 'QGIS Style',
+  rules: [{
+    name: 'QGIS Simple Symbol',
+    symbolizers: [{
+      kind: 'Fill',
+      color: 'transparent',
+      outlineColor: '#FF070B',
+      outlineWidth: 4,
+    }]
+  }]
+} as Style;
+
+export default polygonOutlineOnly;

--- a/data/styles/polygon_point_pattern_fill.ts
+++ b/data/styles/polygon_point_pattern_fill.ts
@@ -1,0 +1,24 @@
+import { Style } from 'geostyler-style';
+
+const polygonPointPatternFill: Style = {
+  name: 'QGIS Style',
+  rules: [{
+    name: 'QGIS Simple Symbol',
+    symbolizers: [{
+      kind: 'Fill',
+      graphicFill: {
+        kind: 'Mark',
+        color: '#006C2B',
+        opacity: 1,
+        radius: 0.3,
+        rotate: 0,
+        strokeColor: '#000000',
+        strokeOpacity: 1,
+        strokeWidth: 0.2,
+        wellKnownName: 'circle',
+      }
+    }]
+  }]
+} as Style;
+
+export default polygonPointPatternFill;

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "build-browser": "vite build",
     "build-dist": "tsc",
     "build": "npm run build-browser && npm run build-dist",
+    "prepare": "npm run build",
     "lint:test:build": "npm run lint && npm run test && npm run build",
     "lint:test": "npm run lint && npm run test",
     "lint": "eslint -c .eslintrc.cjs --ext .ts . && tsc --noEmit",

--- a/src/QGISStyleParser.spec.ts
+++ b/src/QGISStyleParser.spec.ts
@@ -1,17 +1,19 @@
 import * as fs from 'fs';
-import QGISStyleParser from './QGISStyleParser';
 import line_simple from '../data/styles/line_simple';
-import point_simple from '../data/styles/point_simple';
-import point_multiple_symbols from '../data/styles/point_multiple_symbols';
-import point_rules from '../data/styles/point_rules';
+import no_symbolizer from '../data/styles/no_symbolizer';
 import point_categories from '../data/styles/point_categories';
-import point_label from '../data/styles/point_label';
-import point_ranges from '../data/styles/point_ranges';
 import point_external_graphic from '../data/styles/point_external_graphic';
+import point_label from '../data/styles/point_label';
+import point_multiple_symbols from '../data/styles/point_multiple_symbols';
+import point_ranges from '../data/styles/point_ranges';
+import point_rules from '../data/styles/point_rules';
+import point_simple from '../data/styles/point_simple';
+import polygon_outline_only from '../data/styles/polygon_outline_only';
+import polygon_point_pattern_fill from '../data/styles/polygon_point_pattern_fill';
 import polygon_simple from '../data/styles/polygon_simple';
 import polygon_simple_nostyle from '../data/styles/polygon_simple_nostyle';
-import no_symbolizer from '../data/styles/no_symbolizer';
 import text_text_buffer from '../data/styles/text_text_buffer';
+import QGISStyleParser from './QGISStyleParser';
 
 it('QGISStyleParser is defined', () => {
   expect(QGISStyleParser).toBeDefined();
@@ -85,6 +87,20 @@ describe('QMLStyleParser implements StyleParser', () => {
           const { output: geoStylerStyle } = await styleParser.readStyle(qml);
           expect(geoStylerStyle).toBeDefined();
           expect(geoStylerStyle).toEqual(polygon_simple);
+        });
+        it('can read a QML FillSymbolizer with only an outline', async () => {
+          expect.assertions(2);
+          const qml = fs.readFileSync(`./data/${qmlFolder}/polygon_outline_only.qml`, 'utf8');
+          const { output: geoStylerStyle } = await styleParser.readStyle(qml);
+          expect(geoStylerStyle).toBeDefined();
+          expect(geoStylerStyle).toEqual(polygon_outline_only);
+        });
+        it('can read a QML FillSymbolizer with a PointPatternFill', async () => {
+          expect.assertions(2);
+          const qml = fs.readFileSync(`./data/${qmlFolder}/polygon_point_pattern_fill.qml`, 'utf8');
+          const { output: geoStylerStyle } = await styleParser.readStyle(qml);
+          expect(geoStylerStyle).toBeDefined();
+          expect(geoStylerStyle).toEqual(polygon_point_pattern_fill);
         });
       });
       describe('FillSymbolizer with no style', () => {

--- a/src/QGISStyleParser.ts
+++ b/src/QGISStyleParser.ts
@@ -654,9 +654,15 @@ export class QGISStyleParser implements StyleParser {
 
       const qmlMarkerProps: any = qmlSymbolizerLayerPropsToObject(symbolizerLayer);
 
-      const outlineStyle = qmlMarkerProps?.outline_style || 'solid';
+      let outlineStyle = qmlMarkerProps?.outline_style || 'solid';
       if (qmlMarkerProps.outline_color && 'no' !== outlineStyle) {
         fillSymbolizer.outlineColor = this.qmlColorToHex(qmlMarkerProps.outline_color);
+      }
+      // in some cases, QGIS will use line_* instead of outline_*
+      const lineStyle = qmlMarkerProps?.line_style;
+      if (!fillSymbolizer.outlineColor && lineStyle && lineStyle !== 'no') {
+        outlineStyle = lineStyle;
+        fillSymbolizer.outlineColor = this.qmlColorToHex(qmlMarkerProps.line_color);
       }
 
       let fillStyle = qmlMarkerProps?.style || 'solid';
@@ -674,6 +680,11 @@ export class QGISStyleParser implements StyleParser {
         fillSymbolizer.outlineWidth = parseFloat(qmlMarkerProps.outline_width);
       }
 
+      // if you supply a fill with an outline color and no fill color,
+      // it will make the background black.
+      if (fillSymbolizer.outlineColor && !fillSymbolizer.color){
+        fillSymbolizer.color = 'transparent';
+      }
       return fillSymbolizer;
     });
   }


### PR DESCRIPTION
This supplants #605 because the required rebase would otherwise be problematic for our internal infrastructure.

- handles graphic fills.  Multiple graphic fills will be split into multiple layers.
- handles outline-only fills by adding a transparent color.

Concurrently developed with https://github.com/geostyler/geostyler-mapbox-parser/pull/365