### PR TITLE
Assignment of font-weight and font-style while reading QML

### DIFF
--- a/src/QGISStyleParser.ts
+++ b/src/QGISStyleParser.ts
@@ -481,6 +481,13 @@ export class QGISStyleParser implements StyleParser {
     if (styleProperties.fontFamily) {
       textSymbolizer.font = [styleProperties.fontFamily];
     }
+    if (styleProperties.fontWeight && styleProperties.fontWeight>=70) {
+      // see src/core/symbology/qgssymbollayerutils.cpp, QgsSymbolLayerUtils::encodeSldFontWeight
+      textSymbolizer.fontWeight = 'bold';
+    }
+    if (styleProperties.fontItalic && parseFloat(styleProperties.fontItalic) > 0) {
+      textSymbolizer.fontStyle = 'italic';
+    }
     if (styleProperties.fontLetterSpacing && parseFloat(styleProperties.fontLetterSpacing) > 0) {
       textSymbolizer.letterSpacing = parseFloat(styleProperties.fontLetterSpacing);
     }


### PR DESCRIPTION
Assigns the properties `textSymbolizer.fontWeight` and `textSymbolizer.fontStyle` if converting qml label-settings to a TextSymbolizer. Until now, these settings were ignored.