### PR TITLE
Assignment of textSymbolizer.opacity while reading QML

### DIFF
--- a/src/QGISStyleParser.ts
+++ b/src/QGISStyleParser.ts
@@ -470,6 +470,11 @@ export class QGISStyleParser implements StyleParser {
 
     if (styleProperties.textColor) {
       textSymbolizer.color = this.qmlColorToHex(styleProperties.textColor);
+      const textOpacity =  this.qmlColorToOpacity(styleProperties.textColor);
+      if (textOpacity!==undefined && textOpacity!==1) {
+        // don't break tests: if opacity is default, don't set it
+        textSymbolizer.opacity = textOpacity;
+      }
     }
     if (styleProperties.fieldName) {
       // TODO parse fieldName templates like: "'ID: ' || ID"


### PR DESCRIPTION
Assigns the property `textSymbolizer.opacity` if converting qml label-settings to a TextSymbolizer. The property is derived from the `text-color`, and analogous to markers, lines and fills, this opacity is used for the whole symbolizer.