### PR TITLE
Preserve more compatibility by setting marker-opacity to 0 if both fill-opacity and stroke-opacity are 0

### DIFF
--- a/src/QGISStyleParser.ts
+++ b/src/QGISStyleParser.ts
@@ -812,6 +812,17 @@ export class QGISStyleParser implements StyleParser {
       (_value) => {markSymbolizer.strokeWidthUnit = _value;}, true
     );
 
+    // for compatibility and for not breaking existing tests, we can set the whole marker
+    // to transparent if fill is fully transparent and stroke too or if there is no outline
+    if (markSymbolizer.fillOpacity === 0 && (!qmlMarkerProps.outline_color || markSymbolizer.strokeOpacity === 0)) {
+      markSymbolizer.fillOpacity = undefined;
+      markSymbolizer.opacity = 0;
+    }
+    else {
+      // in this case, the opacity is only controlled by the fillOpacity and/or strokeOpacity
+      markSymbolizer.opacity = 1;
+    }
+
     return markSymbolizer;
   }
 


### PR DESCRIPTION
A recently submitted pull request has fixed the issue where the `Opacity` property (instead of the `FillOpacity` property) was assigned from the transparency value of the fill-color.
However, in order to maintain maximum compatibility, I still wanted to set `Opacity` to 0 if both `FillOpacity` and `StrokeOpacity` are 0 (i.e., the symbol is completely invisible). Unfortunately, after several adjustments, this correction was lost and is hereby resubmitted.